### PR TITLE
Dev mat exp

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,7 @@ CPPFLAGS = $(addprefix -I,$(INCLUDES))
 
 ifeq ($(USE_MKL), true)
 	LIBS := 
-	CXXLINKS  :=  -parallel -L${MKLROOT}/lib/intel64 -lmkl_intel_ilp64 -lmkl_core -lmkl_sequential -lmkl_blacs_intelmpi_ilp64 -lpthread -lm
+	CXXLINKS  :=  -parallel -L${MKLROOT}/lib/intel64 -lmkl_intel_ilp64 -lmkl_core -lmkl_sequential -lmkl_blacs_intelmpi_ilp64 -lpthread -lm -ldl
 	CPPFLAGS  +=  -DARMA_BLAS_LONG -DMKL_ILP64 -I${MKLROOT}/include -O2 -DARMA_DONT_USE_WRAPPER 
 else
 	LIBS :=  $(ARMA_LIB) 
@@ -42,6 +42,13 @@ APP_OBJ := $(addsuffix .o, $(addprefix $(OBJPATH)/, $(APP)) )
 
 vpath %.cpp $(sort $(dir $(SOURCE)))
 
+EXPOKIT_SRC := $(wildcard expokit/*.f)
+EXPOKIT_OBJ := ../obj/expokit.o ../obj/mataid.o
+vpath %.f $(sort $(dir $(EXPOKIT_SRC)))
+FC          := mpifort
+FFLAGS      := -I${MKLROOT}/include
+FLINKS      := -L${MKLROOT}/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lmkl_blacs_intelmpi_lp64 -lpthread -lm -ldl -nofor-main -cxxlib
+
 .PHONY : all clean
 
 all : $(DESTINATION)
@@ -61,8 +68,8 @@ $(addprefix $(OBJPATH)/, $(DEPS)) : $(OBJPATH)/%.d : %.cpp | $(OBJPATH)
 
 -include $(addprefix $(OBJPATH)/, $(DEPS))
 
-$(DESTINATION) : $(addprefix $(OBJPATH)/, $(OBJS)) | $(BINPATH)
-	$(CC) -o $@ $(OBJPATH)/$(notdir $@).o $(filter-out $(APP_OBJ), $(addprefix $(OBJPATH)/, $(OBJS)) ) -L$(LIBPATH) $(addprefix -l,$(LIBS)) $(CXXLINKS)
+$(DESTINATION) : $(addprefix $(OBJPATH)/, $(OBJS)) $(EXPOKIT_OBJ) | $(BINPATH)
+	$(FC) -o $@ $(OBJPATH)/$(notdir $@).o $(filter-out $(APP_OBJ), $(addprefix $(OBJPATH)/, $(OBJS))) $(EXPOKIT_OBJ) -L$(LIBPATH) $(addprefix -l,$(LIBS)) $(FLINKS)
 
 $(addprefix $(OBJPATH)/, %.o) : %.cpp | $(OBJPATH)
 	$(CC) -c $< -o $@ $(CPPFLAGS)
@@ -73,3 +80,8 @@ $(OBJPATH) :
 $(BINPATH) :
 	@mkdir -p $(BINPATH)
 
+$(OBJPATH)/expokit.o : expokit.f | $(OBJPATH)
+	$(FC) -c $< -o $@ $(FFLAGS)
+
+$(OBJPATH)/mataid.o : mataid.f | $(OBJPATH)
+	$(FC) -c $< -o $@ $(FFLAGS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,6 +2,7 @@
 # If you have Malab installed, pleas set $(HAS_MATLAB) = true, 
 # and define $(MATLAB_LIB_PATH) and $(MATLAB_INC_PATH) in your .bashrc file.
 # If you want to link the program by INTEL MKL libaray, set $(USE_MKL)=true in your .bashrc file.
+# If you are using INTEL MPI, set $(MPI_INTEL)=true in your .bashrc file.
 BINPATH := ../bin
 OBJPATH := ../obj
 
@@ -20,7 +21,7 @@ CPPFLAGS = $(addprefix -I,$(INCLUDES))
 ifeq ($(USE_MKL), true)
 	LIBS := 
 	CXXLINKS  :=  -parallel -L${MKLROOT}/lib/intel64 -lmkl_intel_ilp64 -lmkl_core -lmkl_sequential -lmkl_blacs_intelmpi_ilp64 -lpthread -lm -ldl
-	CPPFLAGS  +=  -DARMA_BLAS_LONG -DMKL_ILP64 -I${MKLROOT}/include -O2 -DARMA_DONT_USE_WRAPPER 
+	CPPFLAGS  +=  -DARMA_BLAS_LONG -DMKL_ILP64 -m64 -I${MKLROOT}/include -DARMA_DONT_USE_WRAPPER 
 else
 	LIBS :=  $(ARMA_LIB) 
 	CXXLINKS  := 
@@ -46,8 +47,13 @@ EXPOKIT_SRC := $(wildcard expokit/*.f)
 EXPOKIT_OBJ := ../obj/expokit.o ../obj/mataid.o
 vpath %.f $(sort $(dir $(EXPOKIT_SRC)))
 FC          := mpifort
-FFLAGS      := -I${MKLROOT}/include
-FLINKS      := -L${MKLROOT}/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lmkl_blacs_intelmpi_lp64 -lpthread -lm -ldl -nofor-main -cxxlib
+ifeq ($(MPI_INTEL), true)
+  FFLAGS      := -I${MKLROOT}/include
+  FLINKS      := -L${MKLROOT}/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lmkl_blacs_intelmpi_lp64 -lpthread -lm -ldl -nofor-main -cxxlib
+else
+  FFLAGS      := -m64 -I${MKLROOT}/include
+  CXXLINKS    := -L${MKLROOT}/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential -lmkl_blacs_intelmpi_lp64 -lpthread -lm -ldl -lgfortran
+endif
 
 .PHONY : all clean
 
@@ -68,8 +74,13 @@ $(addprefix $(OBJPATH)/, $(DEPS)) : $(OBJPATH)/%.d : %.cpp | $(OBJPATH)
 
 -include $(addprefix $(OBJPATH)/, $(DEPS))
 
+ifeq ($(MPI_INTEL), true)
 $(DESTINATION) : $(addprefix $(OBJPATH)/, $(OBJS)) $(EXPOKIT_OBJ) | $(BINPATH)
 	$(FC) -o $@ $(OBJPATH)/$(notdir $@).o $(filter-out $(APP_OBJ), $(addprefix $(OBJPATH)/, $(OBJS))) $(EXPOKIT_OBJ) -L$(LIBPATH) $(addprefix -l,$(LIBS)) $(FLINKS)
+else
+$(DESTINATION) : $(addprefix $(OBJPATH)/, $(OBJS)) $(EXPOKIT_OBJ) | $(BINPATH)
+	$(CC) -o $@ $(OBJPATH)/$(notdir $@).o $(filter-out $(APP_OBJ), $(addprefix $(OBJPATH)/, $(OBJS))) $(EXPOKIT_OBJ) -L$(LIBPATH) $(addprefix -l,$(LIBS)) $(CXXLINKS)
+endif
 
 $(addprefix $(OBJPATH)/, %.o) : %.cpp | $(OBJPATH)
 	$(CC) -c $< -o $@ $(CPPFLAGS)

--- a/src/application/MatExpTest.cpp
+++ b/src/application/MatExpTest.cpp
@@ -12,10 +12,22 @@ int  main(int argc, char* argv[])
 
     cx_double prefactor = 3.0;
 
+    cout << "input data: " << endl;
+    cout << prefactor * H << endl;
+    cx_mat res;
+    
     MatExp expM(H, prefactor, MatExp::ArmadilloExpMat);
     expM.run();
-
-    cx_mat res = expM.getResultMatrix();
+    res = expM.getResultMatrix();
+    cout << "arma output: " << endl;
     cout << res << endl;
+    
+    MatExp expM2(H, prefactor, MatExp::PadeApproximation);
+    expM2.run();
+
+    res = expM2.getResultMatrix();
+    cout << "pade output: " << endl;
+    cout << res << endl;
+    
     return 0;
 }

--- a/src/expokit/DLARAN.f
+++ b/src/expokit/DLARAN.f
@@ -1,0 +1,92 @@
+! code form sample_z.f in expokit
+*----------------------------------------------------------------------|
+      DOUBLE PRECISION FUNCTION DLARAN( ISEED )
+*
+*  -- LAPACK auxiliary routine (version 2.0) --
+*     Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,
+*     Courant Institute, Argonne National Lab, and Rice University
+*     February 29, 1992
+*
+*     .. Array Arguments ..
+      INTEGER            ISEED( 4 )
+*     ..
+*
+*  Purpose
+*  =======
+*
+*  DLARAN returns a random real number from a uniform (0,1)
+*  distribution.
+*
+*  Arguments
+*  =========
+*
+*  ISEED   (input/output) INTEGER array, dimension (4)
+*          On entry, the seed of the random number generator; the array
+*          elements must be between 0 and 4095, and ISEED(4) must be
+*          odd.
+*          On exit, the seed is updated.
+*
+*  Further Details
+*  ===============
+*
+*  This routine uses a multiplicative congruential method with modulus
+*  2**48 and multiplier 33952834046453 (see G.S.Fishman,
+*  'Multiplicative congruential random number generators with modulus
+*  2**b: an exhaustive analysis for b = 32 and a partial analysis for
+*  b = 48', Math. Comp. 189, pp 331-344, 1990).
+*
+*  48-bit integers are stored in 4 integer array elements with 12 bits
+*  per element. Hence the routine is portable across machines with
+*  integers of 32 bits or more.
+*
+*  =====================================================================
+*
+*     .. Parameters ..
+      INTEGER            M1, M2, M3, M4
+      PARAMETER          ( M1 = 494, M2 = 322, M3 = 2508, M4 = 2549 )
+      DOUBLE PRECISION   ONE
+      PARAMETER          ( ONE = 1.0D+0 )
+      INTEGER            IPW2
+      DOUBLE PRECISION   R
+      PARAMETER          ( IPW2 = 4096, R = ONE / IPW2 )
+*     ..
+*     .. Local Scalars ..
+      INTEGER            IT1, IT2, IT3, IT4
+*     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          DBLE, MOD
+*     ..
+*     .. Executable Statements ..
+*
+*     multiply the seed by the multiplier modulo 2**48
+*
+      IT4 = ISEED( 4 )*M4
+      IT3 = IT4 / IPW2
+      IT4 = IT4 - IPW2*IT3
+      IT3 = IT3 + ISEED( 3 )*M4 + ISEED( 4 )*M3
+      IT2 = IT3 / IPW2
+      IT3 = IT3 - IPW2*IT2
+      IT2 = IT2 + ISEED( 2 )*M4 + ISEED( 3 )*M3 + ISEED( 4 )*M2
+      IT1 = IT2 / IPW2
+      IT2 = IT2 - IPW2*IT1
+      IT1 = IT1 + ISEED( 1 )*M4 + ISEED( 2 )*M3 + ISEED( 3 )*M2 +
+     $      ISEED( 4 )*M1
+      IT1 = MOD( IT1, IPW2 )
+*
+*     return updated seed
+*
+      ISEED( 1 ) = IT1
+      ISEED( 2 ) = IT2
+      ISEED( 3 ) = IT3
+      ISEED( 4 ) = IT4
+*
+*     convert 48-bit integer to a real number in the interval (0,1)
+*
+      DLARAN = R*( DBLE( IT1 )+R*( DBLE( IT2 )+R*( DBLE( IT3 )+R*
+     $         ( DBLE( IT4 ) ) ) ) )
+      RETURN
+*
+*     End of DLARAN
+*
+      END
+*----------------------------------------------------------------------|

--- a/src/expokit/README
+++ b/src/expokit/README
@@ -1,0 +1,141 @@
+This is the set of files related to Expokit, the matrix exponential
+package. Please report bugs and comments to rbs@maths.uq.edu.au.
+
+This version dated: Oct 7, 1997
+URL:  http://www.maths.uq.edu.au/expokit
+
+Notes:
+======
+1. w(t) = exp(t*A)v is the analytic solution of the homogeneous 
+   ODE problem:
+               w'(t) = Aw(t),  w(0) = v
+
+2. w(t) = exp(t*A)*v + t*phi(t*A)u, where phi(z) = (exp(z)-1)/z,
+   is the analytic solution of the nonhomogeneous ODE problem:
+               w'(t) = Aw(t) + u,  w(0) = v
+
+------------------------------------------------------------------------
+
+expokit.tar.gz       complete expokit package, current release
+------------------------------------------------------------------------
+
+Otherwise...
+
+expodoc.ps  description of the methods used in the package
+README      this file
+Makefile    Fortran makefile
+expokit.f   all-in-one file, i.e., concatenation of all .f files, 
+            except BLAS, LAPACK and the aid and driver routines.
+            Hence a minimal Fortran trial would include:
+            Makefile, expokit.f, blas.f, lapack.f, mataid.f, 
+            and one of the drivers.
+
+
+||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+||||||||||||||||||||||||||||||||  FORTRAN  |||||||||||||||||||||||||||||
+||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
+REAL      COMPLEX
+=======================================================================|
+                          SMALL DENSE ROUTINES
+
+dgpadm.f  zgpadm.f   exp(t*A) in full using irreducible Pade, A general
+dspadm.f  zhpadm.f   exp(t*A) in full using Pade, A symmetric/Hermitian
+dgchbv.f  zgchbv.f   exp(t*A)*v using Chebyshev, A general
+dschbv.f             exp(t*A)*v using Chebyshev, A symmetric
+dnchbv.f  znchbv.f   exp(t*A)*v using Chebyshev, A upper Hessenberg
+
+blas.f               minimal substitute to BLAS
+lapack.f             minimal substitute to LAPACK
+
+=======================================================================|
+                           LARGE SPARSE ROUTINES
+
+dmexpv.f             exp(t*A)*v using Krylov, A is a Markov matrix
+dgexpv.f  zgexpv.f   exp(t*A)*v using Krylov, A general
+dsexpv.f  zhexpv.f   exp(t*A)*v using Krylov, A symmetric/Hermitian
+dgphiv.f  zgphiv.f   exp(t*A)*v + t*phi(t*A)*u using Krylov, A general
+dsphiv.f  zhphiv.f   exp(t*A)*v + t*phi(t*A)*u using Krylov, A sym/Hem
+
+dgcnvr.f  zgcnvr.f   convert a sparse format into another one
+dgmatv.f  zgmatv.f   matrix-vector utilities
+loadhb.f             load and converts a Harwell-Boeing matrix
+
+mataid.f             concatenation of the files above (i.e., __cnvr.f, 
+                     __matv.f, and loadhb.f) 
+
+=======================================================================|
+                             SAMPLE DRIVERS
+
+sample_d.f           dense example
+sample_g.f           general example
+sample_z.f           Complex example
+sample_b.f           forward-backward example
+sample_m.f           Markov example
+sample_p.f           phi example
+
+clock.f              utility timer function - MUST BE SET BY THE USER
+		     
+c1024.crs.gz         Markov chains matrix used in sample_m.f
+gr3030.gz            Harwell-Boeing matrix used in sample_b.f
+orani678.gz          Harwell-Boeing matrix used in sample_g.f/_p.f
+bcspwr10.gz          Harwell-Boeing pattern used in sample_z.f
+
+||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+|||||||||||||||||||||||||||||||  MATLAB  |||||||||||||||||||||||||||||||
+||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
+chbv.m               Chebyshev algorithm for w = exp(t*A)v
+padm.m               irreducible Pade algorithm for exp(t*A)
+phiv.m               Krylov algorithm for w = exp(t*A)*v + t*phi(t*A)u
+expv.m               Krylov algorithm for w = exp(t*A)*v
+mexpv.m              Markov algorithm for w = exp(t*A)*v
+		     
+mat2ccs.m            save matrix into an ascii file under CCS format
+mat2coo.m            save matrix into an ascii file under COO format
+mat2crs.m            save matrix into an ascii file under CRS format
+		     
+loadccs.m            load matrix from a file under CCS format
+loadcoo.m            load matrix from a file under COO format
+loadcrs.m            load matrix from a file under CRS format
+		     
+example.m            sample program illustrating the use of _expv.m
+
+
+||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+||||||||||||||||||||||||||||||  PLATFORMS  |||||||||||||||||||||||||||||
+||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
+The drivers have been successfully tested on the following platforms:
+
+SUN 
+-------------------------------
+       SPARC workstation
+
+IBM
+--------------------------------
+       RS/6000 workstation
+       SP2 (one node)
+
+SGI
+--------------------------------
+       Indy workstation
+       Power Challenge (one node)
+
+
+Others? Please notify.
+
+
+||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+|||||||||||||||||||||||||||||||    BUGS    |||||||||||||||||||||||||||||
+||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+
+On some systems, the compilation of Expokit will generate a warning
+message about an incompatibility of type in the call of DNCHBV. This is
+due to the fact that a real array is used as argument where a complex 
+array is expected. This is an artefact to avoid an otherwise idle
+complex array in the calling routine. Thus it is not a bug as such 
+and no side-effects arise. There is a notice about this in the header 
+of DNCHBV.
+
+

--- a/src/expokit/copyright
+++ b/src/expokit/copyright
@@ -1,0 +1,37 @@
+                              NOTICE
+
+Permission to use, copy, modify, and distribute EXPOKIT and its
+supporting documentation for non-commercial purposes, is hereby
+granted without fee, provided that this permission message and
+copyright notice appear in all copies. Approval must be sought for
+commercial purposes.
+
+Neither the Institution (University of Queensland) nor the Authors
+make any representations about the suitability of this software for
+any purpose.  This software is provided ``as is'' without express or
+implied warranty.
+
+The work resulting from EXPOKIT has been published in ACM-Transactions 
+on Mathematical Software, 24(1):130-156, 1998.
+
+The bibtex record of the citation:
+
+@ARTICLE{EXPOKIT,
+        AUTHOR  = {Sidje, R. B.},
+        TITLE   = {{\sc Expokit.} {S}oftware {P}ackage for
+		  {C}omputing {M}atrix {E}xponentials},
+        JOURNAL = {ACM Trans. Math. Softw.},
+        VOLUME  = {24},
+        NUMBER  = {1},
+        PAGES   = {130-156}
+        YEAR    = {1998}
+}
+
+Certain elements of the current software may include inadequacies
+that may be corrected at any time, as they are discovered. The Web 
+always contains the latest updates.
+
+                             Roger B. Sidje
+           Department of Mathematics, University of Queensland 
+     Brisbane, QLD-4072, Australia, (c) 1996-1999 All Rights Reserved
+

--- a/src/expokit/expokit.f
+++ b/src/expokit/expokit.f
@@ -1,0 +1,4627 @@
+*----------------------------------------------------------------------|
+      subroutine DMEXPV( n, m, t, v, w, tol, anorm,
+     .                   wsp,lwsp, iwsp,liwsp, matvec, itrace,iflag )
+
+      implicit none
+      integer n, m, lwsp, liwsp, itrace, iflag, iwsp(liwsp)
+      double precision t, tol, anorm, v(n), w(n), wsp(lwsp)
+      external matvec
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  DMEXPV computes w = exp(t*A)*v - Customised for MARKOV CHAINS.
+*
+*     It does not compute the matrix exponential in isolation but
+*     instead, it computes directly the action of the exponential
+*     operator on the operand vector. This way of doing so allows 
+*     for addressing large sparse problems. 
+*
+*     The method used is based on Krylov subspace projection
+*     techniques and the matrix under consideration interacts only
+*     via the external routine `matvec' performing the matrix-vector 
+*     product (matrix-free method).
+*
+*     This is a customised version for Markov Chains. This means that a
+*     check is done within this code to ensure that the resulting vector 
+*     w is a probability vector, i.e., w must have all its components 
+*     in [0,1], with sum equal to 1. This check is done at some expense
+*     and the user may try DGEXPV which is cheaper since it ignores 
+*     probability constraints.
+*
+*     IMPORTANT: The check assumes that the transition rate matrix Q
+*                satisfies Qe = 0, where e=(1,...,1)'. Don't use DMEXPV
+*                if this condition does not hold. Use DGEXPV instead.
+*                DMEXPV/DGEXPV require the matrix-vector product 
+*                y = A*x = Q'*x, i.e, the TRANSPOSE of Q times a vector.
+*                Failure to remember this leads to wrong results.
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     n      : (input) order of the principal matrix A.
+*                      
+*     m      : (input) maximum size for the Krylov basis.
+*                      
+*     t      : (input) time at wich the solution is needed (can be < 0).
+*                      
+*     v(n)   : (input) given operand vector.
+*
+*     w(n)   : (output) computed approximation of exp(t*A)*v.
+*
+*     tol    : (input/output) the requested acurracy tolerance on w. 
+*              If on input tol=0.0d0 or tol is too small (tol.le.eps)
+*              the internal value sqrt(eps) is used, and tol is set to
+*              sqrt(eps) on output (`eps' denotes the machine epsilon).
+*              (`Happy breakdown' is assumed if h(j+1,j) .le. anorm*tol)
+*
+*     anorm  : (input) an approximation of some norm of A.
+*
+*   wsp(lwsp): (workspace) lwsp .ge. n*(m+1)+n+(m+2)^2+4*(m+2)^2+ideg+1
+*                                   +---------+-------+---------------+
+*              (actually, ideg=6)        V        H     wsp for PADE
+*                   
+* iwsp(liwsp): (workspace) liwsp .ge. m+2
+*
+*     matvec : external subroutine for matrix-vector multiplication.
+*              synopsis: matvec( x, y )
+*                        double precision x(*), y(*)
+*              computes: y(1:n) <- A*x(1:n)
+*                        where A is the principal matrix.
+*
+*              IMPORTANT: DMEXPV requires the product y = Ax = Q'x, i.e.
+*              the TRANSPOSE of the transition rate matrix.
+*
+*     itrace : (input) running mode. 0=silent, 1=print step-by-step info
+*
+*     iflag  : (output) exit flag.
+*              <0 - bad input arguments 
+*               0 - no problem
+*               1 - maximum number of steps reached without convergence
+*               2 - requested tolerance was too high
+*
+*-----Accounts on the computation--------------------------------------|
+*     Upon exit, an interested user may retrieve accounts on the 
+*     computations. They are located in the workspace arrays wsp and 
+*     iwsp as indicated below: 
+*
+*     location  mnemonic                 description
+*     -----------------------------------------------------------------|
+*     iwsp(1) = nmult, number of matrix-vector multiplications used
+*     iwsp(2) = nexph, number of Hessenberg matrix exponential evaluated
+*     iwsp(3) = nscale, number of repeated squaring involved in Pade
+*     iwsp(4) = nstep, number of integration steps used up to completion 
+*     iwsp(5) = nreject, number of rejected step-sizes
+*     iwsp(6) = ibrkflag, set to 1 if `happy breakdown' and 0 otherwise
+*     iwsp(7) = mbrkdwn, if `happy brkdown', basis-size when it occured
+*     -----------------------------------------------------------------|
+*     wsp(1)  = step_min, minimum step-size used during integration
+*     wsp(2)  = step_max, maximum step-size used during integration
+*     wsp(3)  = x_round, maximum among all roundoff errors (lower bound) 
+*     wsp(4)  = s_round, sum of roundoff errors (lower bound)
+*     wsp(5)  = x_error, maximum among all local truncation errors
+*     wsp(6)  = s_error, global sum of local truncation errors
+*     wsp(7)  = tbrkdwn, if `happy breakdown', time when it occured
+*     wsp(8)  = t_now, integration domain successfully covered
+*     wsp(9)  = hump, i.e., max||exp(sA)||, s in [0,t] (or [t,0] if t<0)
+*     wsp(10) = ||w||/||v||, scaled norm of the solution w.
+*     -----------------------------------------------------------------|
+*     The `hump' is a measure of the conditioning of the problem. The
+*     matrix exponential is well-conditioned if hump = 1, whereas it is
+*     poorly-conditioned if hump >> 1. However the solution can still be
+*     relatively fairly accurate even when the hump is large (the hump 
+*     is an upper bound), especially when the hump and the scaled norm
+*     of w [this is also computed and returned in wsp(10)] are of the 
+*     same order of magnitude (further details in reference below).
+*     Markov chains are usually well-conditioned problems.
+*
+*----------------------------------------------------------------------|
+*-----The following parameters may also be adjusted herein-------------|
+*
+      integer mxstep, mxreject, ideg
+      double precision delta, gamma
+      parameter( mxstep   = 500,
+     .           mxreject = 0,
+     .           ideg     = 6,
+     .           delta    = 1.2d0,
+     .           gamma    = 0.9d0 )
+
+*     mxstep  : maximum allowable number of integration steps.
+*               The value 0 means an infinite number of steps.
+* 
+*     mxreject: maximum allowable number of rejections at each step. 
+*               The value 0 means an infinite number of rejections.
+*
+*     ideg    : the Pade approximation of type (ideg,ideg) is used as 
+*               an approximation to exp(H). The value 0 switches to the
+*               uniform rational Chebyshev approximation of type (14,14)
+*
+*     delta   : local truncation error `safety factor'
+*
+*     gamma   : stepsize `shrinking factor'
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      integer i, j, k1, mh, mx, iv, ih, j1v, ns, ifree, lfree, iexph,
+     .        ireject,ibrkflag,mbrkdwn, nmult, nreject, nexph, nscale,
+     .        nstep
+      double precision sgn, t_out, tbrkdwn, step_min,step_max, err_loc,
+     .                 s_error, x_error, t_now, t_new, t_step, t_old,
+     .                 xm, beta, break_tol, p1, p2, p3, eps, rndoff,
+     .                 vnorm, avnorm, hj1j, hij, hump, SQR1,
+     .                 roundoff, s_round, x_round
+
+      intrinsic AINT,ABS,DBLE,LOG10,MAX,MIN,NINT,SIGN,SQRT
+      double precision DDOT, DNRM2, DASUM
+
+*---  check restrictions on input parameters ...
+      iflag = 0
+      if ( lwsp.lt.n*(m+2)+5*(m+2)**2+ideg+1 ) iflag = -1
+      if ( liwsp.lt.m+2 ) iflag = -2
+      if ( m.ge.n .or. m.le.0 ) iflag = -3
+      if ( iflag.ne.0 ) stop 'bad sizes (in input of DMEXPV)'
+*
+*---  initialisations ...
+*
+      k1 = 2
+      mh = m + 2
+      iv = 1
+      ih = iv + n*(m+1) + n
+      ifree = ih + mh*mh
+      lfree = lwsp - ifree + 1
+
+      ibrkflag = 0
+      mbrkdwn  = m
+      nmult    = 0
+      nreject  = 0
+      nexph    = 0
+      nscale   = 0
+
+      sgn      = SIGN( 1.0d0,t )
+      t_out    = ABS( t )
+      tbrkdwn  = 0.0d0
+      step_min = t_out
+      step_max = 0.0d0
+      nstep    = 0
+      s_error  = 0.0d0
+      s_round  = 0.0d0
+      x_error  = 0.0d0
+      x_round  = 0.0d0
+      t_now    = 0.0d0
+      t_new    = 0.0d0
+
+      p1 = 4.0d0/3.0d0
+ 1    p2 = p1 - 1.0d0
+      p3 = p2 + p2 + p2
+      eps = ABS( p3-1.0d0 )
+      if ( eps.eq.0.0d0 ) go to 1
+      if ( tol.le.eps ) tol = SQRT( eps )
+      rndoff = eps*anorm
+
+      break_tol = 1.0d-7
+*>>>  break_tol = tol
+*>>>  break_tol = anorm*tol
+
+      call DCOPY( n, v,1, w,1 )
+      beta = DNRM2( n, w,1 )
+      vnorm = beta
+      hump = beta
+*
+*---  obtain the very first stepsize ...
+*
+      SQR1 = SQRT( 0.1d0 )
+      xm = 1.0d0/DBLE( m )
+      p1 = tol*(((m+1)/2.72D0)**(m+1))*SQRT(2.0D0*3.14D0*(m+1))
+      t_new = (1.0d0/anorm)*(p1/(4.0d0*beta*anorm))**xm
+      p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+      t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+*
+*---  step-by-step integration ...
+*
+ 100  if ( t_now.ge.t_out ) goto 500
+
+      nstep = nstep + 1
+      t_step = MIN( t_out-t_now, t_new )
+
+      p1 = 1.0d0/beta
+      do i = 1,n
+         wsp(iv + i-1) = p1*w(i)
+      enddo
+      do i = 1,mh*mh
+         wsp(ih+i-1) = 0.0d0
+      enddo
+*
+*---  Arnoldi loop ...
+*
+      j1v = iv + n
+      do 200 j = 1,m
+         nmult = nmult + 1
+         call matvec( wsp(j1v-n), wsp(j1v) )
+         do i = 1,j
+            hij = DDOT( n, wsp(iv+(i-1)*n),1, wsp(j1v),1 )
+            call DAXPY( n, -hij, wsp(iv+(i-1)*n),1, wsp(j1v),1 )
+            wsp(ih+(j-1)*mh+i-1) = hij
+         enddo
+         hj1j = DNRM2( n, wsp(j1v),1 )
+*---     if `happy breakdown' go straightforward at the end ... 
+         if ( hj1j.le.break_tol ) then
+            print*,'happy breakdown: mbrkdwn =',j,' h =',hj1j
+            k1 = 0
+            ibrkflag = 1
+            mbrkdwn = j
+            tbrkdwn = t_now
+            t_step = t_out-t_now
+            goto 300
+         endif
+         wsp(ih+(j-1)*mh+j) = hj1j
+         call DSCAL( n, 1.0d0/hj1j, wsp(j1v),1 )
+         j1v = j1v + n
+ 200  continue
+      nmult = nmult + 1
+      call matvec( wsp(j1v-n), wsp(j1v) )
+      avnorm = DNRM2( n, wsp(j1v),1 )
+*
+*---  set 1 for the 2-corrected scheme ...
+*
+ 300  continue
+      wsp(ih+m*mh+m+1) = 1.0d0
+*
+*---  loop while ireject<mxreject until the tolerance is reached ...
+*
+      ireject = 0
+ 401  continue
+
+*
+*---  compute w = beta*V*exp(t_step*H)*e1 ..
+*
+      nexph = nexph + 1
+      mx = mbrkdwn + k1
+      if ( ideg.ne.0 ) then
+*---     irreducible rational Pade approximation ...
+         call DGPADM( ideg, mx, sgn*t_step, wsp(ih),mh,
+     .                wsp(ifree),lfree, iwsp, iexph, ns, iflag )
+         iexph = ifree + iexph - 1
+         nscale = nscale + ns
+      else
+*---     uniform rational Chebyshev approximation ...
+         iexph = ifree
+         do i = 1,mx
+            wsp(iexph+i-1) = 0.0d0
+         enddo
+         wsp(iexph) = 1.0d0
+         call DNCHBV(mx,sgn*t_step,wsp(ih),mh,wsp(iexph),wsp(ifree+mx))
+      endif
+
+ 402  continue
+* 
+*---  error estimate ...
+* 
+      if ( k1.eq.0 ) then
+         err_loc = tol
+      else
+         p1 = ABS( wsp(iexph+m) )   * beta
+         p2 = ABS( wsp(iexph+m+1) ) * beta * avnorm
+         if ( p1.gt.10.0d0*p2 ) then
+            err_loc = p2
+            xm = 1.0d0/DBLE( m )
+         elseif ( p1.gt.p2 ) then
+            err_loc = (p1*p2)/(p1-p2)
+            xm = 1.0d0/DBLE( m )
+         else
+            err_loc = p1
+            xm = 1.0d0/DBLE( m-1 )
+         endif
+      endif
+*
+*---  reject the step-size if the error is not acceptable ...
+*   
+      if ( (k1.ne.0) .and. (err_loc.gt.delta*t_step*tol) .and.
+     .     (mxreject.eq.0 .or. ireject.lt.mxreject) ) then
+         t_old = t_step
+         t_step = gamma * t_step * (t_step*tol/err_loc)**xm
+         p1 = 10.0d0**(NINT( LOG10( t_step )-SQR1 )-1)
+         t_step = AINT( t_step/p1 + 0.55d0 ) * p1
+         if ( itrace.ne.0 ) then
+            print*,'t_step =',t_old
+            print*,'err_loc =',err_loc
+            print*,'err_required =',delta*t_old*tol
+            print*,'stepsize rejected, stepping down to:',t_step
+         endif
+         ireject = ireject + 1
+         nreject = nreject + 1
+         if ( mxreject.ne.0 .and. ireject.gt.mxreject ) then
+            print*,"Failure in DMEXPV: ---"
+            print*,"The requested tolerance is too high."
+            Print*,"Rerun with a smaller value."
+            iflag = 2
+            return
+         endif
+         goto 401
+      endif
+*
+*---  now update w = beta*V*exp(t_step*H)*e1 and the hump ...
+*
+      mx = mbrkdwn + MAX( 0,k1-1 )
+      call DGEMV( 'n', n,mx,beta,wsp(iv),n,wsp(iexph),1,0.0d0,w,1 )
+      beta = DNRM2( n, w,1 )
+      hump = MAX( hump, beta )
+*
+*---  Markov model constraints ...
+*
+      j = 0
+      do i = 1,n
+         if ( w(i).lt.0.0d0 ) then
+            w(i) = 0.0d0
+            j = j + 1
+         endif
+      enddo
+      p1 = DASUM( n, w,1 )
+      if ( j.gt.0 ) call DSCAL( n, 1.0d0/p1, w,1 )
+      roundoff = DABS( 1.0d0-p1 ) / DBLE( n )
+*
+*---  suggested value for the next stepsize ...
+*
+      t_new = gamma * t_step * (t_step*tol/err_loc)**xm
+      p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+      t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+
+      err_loc = MAX( err_loc, roundoff )
+      err_loc = MAX( err_loc, rndoff )
+*
+*---  update the time covered ...
+*
+      t_now = t_now + t_step
+*
+*---  display and keep some information ...
+*
+      if ( itrace.ne.0 ) then
+         print*,'integration',nstep,'---------------------------------'
+         print*,'scale-square =',ns
+         print*,'wnorm     =',beta
+         print*,'step_size =',t_step
+         print*,'err_loc   =',err_loc
+         print*,'roundoff  =',roundoff
+         print*,'next_step =',t_new
+      endif
+
+      step_min = MIN( step_min, t_step )
+      step_max = MAX( step_max, t_step )
+      s_error = s_error + err_loc
+      s_round = s_round + roundoff
+      x_error = MAX( x_error, err_loc )
+      x_round = MAX( x_round, roundoff )
+
+      if ( mxstep.eq.0 .or. nstep.lt.mxstep ) goto 100
+      iflag = 1
+
+ 500  continue
+
+      iwsp(1) = nmult
+      iwsp(2) = nexph
+      iwsp(3) = nscale
+      iwsp(4) = nstep
+      iwsp(5) = nreject
+      iwsp(6) = ibrkflag
+      iwsp(7) = mbrkdwn
+
+      wsp(1)  = step_min
+      wsp(2)  = step_max
+      wsp(3)  = x_round
+      wsp(4)  = s_round
+      wsp(5)  = x_error
+      wsp(6)  = s_error
+      wsp(7)  = tbrkdwn
+      wsp(8)  = sgn*t_now
+      wsp(9)  = hump/vnorm
+      wsp(10) = beta/vnorm
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine DGPADM( ideg,m,t,H,ldh,wsp,lwsp,ipiv,iexph,ns,iflag )
+
+      implicit none
+      integer ideg, m, ldh, lwsp, iexph, ns, iflag, ipiv(m)
+      double precision t, H(ldh,m), wsp(lwsp)
+
+*-----Purpose----------------------------------------------------------|
+*
+*     Computes exp(t*H), the matrix exponential of a general matrix in
+*     full, using the irreducible rational Pade approximation to the 
+*     exponential function exp(x) = r(x) = (+/-)( I + 2*(q(x)/p(x)) ),
+*     combined with scaling-and-squaring.
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     ideg      : (input) the degre of the diagonal Pade to be used.
+*                 a value of 6 is generally satisfactory.
+*
+*     m         : (input) order of H.
+*
+*     H(ldh,m)  : (input) argument matrix.
+*
+*     t         : (input) time-scale (can be < 0).
+*                  
+*     wsp(lwsp) : (workspace/output) lwsp .ge. 4*m*m+ideg+1.
+*
+*     ipiv(m)   : (workspace)
+*
+*>>>> iexph     : (output) number such that wsp(iexph) points to exp(tH)
+*                 i.e., exp(tH) is located at wsp(iexph ... iexph+m*m-1)
+*                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+*                 NOTE: if the routine was called with wsp(iptr), 
+*                       then exp(tH) will start at wsp(iptr+iexph-1).
+*
+*     ns        : (output) number of scaling-squaring used.
+*
+*     iflag     : (output) exit flag.
+*                      0 - no problem
+*                     <0 - problem
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      integer mm,i,j,k,ih2,ip,iq,iused,ifree,iodd,icoef,iput,iget
+      double precision hnorm,scale,scale2,cp,cq
+
+      intrinsic INT,ABS,DBLE,LOG,MAX
+
+*---  check restrictions on input parameters ...
+      mm = m*m
+      iflag = 0
+      if ( ldh.lt.m ) iflag = -1
+      if ( lwsp.lt.4*mm+ideg+1 ) iflag = -2
+      if ( iflag.ne.0 ) stop 'bad sizes (in input of DGPADM)'
+*
+*---  initialise pointers ...
+*
+      icoef = 1
+      ih2 = icoef + (ideg+1)
+      ip  = ih2 + mm
+      iq  = ip + mm
+      ifree = iq + mm
+*
+*---  scaling: seek ns such that ||t*H/2^ns|| < 1/2; 
+*     and set scale = t/2^ns ...
+*
+      do i = 1,m
+         wsp(i) = 0.0d0
+      enddo
+      do j = 1,m
+         do i = 1,m
+            wsp(i) = wsp(i) + ABS( H(i,j) )
+         enddo
+      enddo
+      hnorm = 0.0d0
+      do i = 1,m
+         hnorm = MAX( hnorm,wsp(i) )
+      enddo
+      hnorm = ABS( t*hnorm )
+      if ( hnorm.eq.0.0d0 ) stop 'Error - null H in input of DGPADM.'
+      ns = MAX( 0,INT(LOG(hnorm)/LOG(2.0d0))+2 )
+      scale = t / DBLE(2**ns)
+      scale2 = scale*scale
+*
+*---  compute Pade coefficients ...
+*
+      i = ideg+1
+      j = 2*ideg+1
+      wsp(icoef) = 1.0d0
+      do k = 1,ideg
+         wsp(icoef+k) = (wsp(icoef+k-1)*DBLE( i-k ))/DBLE( k*(j-k) )
+      enddo
+*
+*---  H2 = scale2*H*H ...
+*
+      call DGEMM( 'n','n',m,m,m,scale2,H,ldh,H,ldh,0.0d0,wsp(ih2),m )
+*
+*---  initialize p (numerator) and q (denominator) ...
+*
+      cp = wsp(icoef+ideg-1)
+      cq = wsp(icoef+ideg)
+      do j = 1,m
+         do i = 1,m
+            wsp(ip + (j-1)*m + i-1) = 0.0d0
+            wsp(iq + (j-1)*m + i-1) = 0.0d0
+         enddo
+         wsp(ip + (j-1)*(m+1)) = cp
+         wsp(iq + (j-1)*(m+1)) = cq
+      enddo
+*
+*---  Apply Horner rule ...
+*
+      iodd = 1
+      k = ideg - 1
+ 100  continue
+      iused = iodd*iq + (1-iodd)*ip
+      call DGEMM( 'n','n',m,m,m, 1.0d0,wsp(iused),m,
+     .             wsp(ih2),m, 0.0d0,wsp(ifree),m )
+      do j = 1,m
+         wsp(ifree+(j-1)*(m+1)) = wsp(ifree+(j-1)*(m+1))+wsp(icoef+k-1)
+      enddo
+      ip = (1-iodd)*ifree + iodd*ip
+      iq = iodd*ifree + (1-iodd)*iq
+      ifree = iused
+      iodd = 1-iodd
+      k = k-1
+      if ( k.gt.0 )  goto 100
+*
+*---  Obtain (+/-)(I + 2*(p\q)) ...
+*
+      if ( iodd .eq. 1 ) then
+         call DGEMM( 'n','n',m,m,m, scale,wsp(iq),m,
+     .                H,ldh, 0.0d0,wsp(ifree),m )
+         iq = ifree
+      else
+         call DGEMM( 'n','n',m,m,m, scale,wsp(ip),m,
+     .                H,ldh, 0.0d0,wsp(ifree),m )
+         ip = ifree
+      endif
+      call DAXPY( mm, -1.0d0,wsp(ip),1, wsp(iq),1 )
+      call DGESV( m,m, wsp(iq),m, ipiv, wsp(ip),m, iflag )
+      if ( iflag.ne.0 ) stop 'Problem in DGESV (within DGPADM)'
+      call DSCAL( mm, 2.0d0, wsp(ip), 1 )
+      do j = 1,m
+         wsp(ip+(j-1)*(m+1)) = wsp(ip+(j-1)*(m+1)) + 1.0d0
+      enddo
+      iput = ip
+      if ( ns.eq.0 .and. iodd.eq.1 ) then
+         call DSCAL( mm, -1.0d0, wsp(ip), 1 )
+         goto 200
+      endif
+*
+*--   squaring : exp(t*H) = (exp(t*H))^(2^ns) ...
+*
+      iodd = 1
+      do k = 1,ns
+         iget = iodd*ip + (1-iodd)*iq
+         iput = (1-iodd)*ip + iodd*iq
+         call DGEMM( 'n','n',m,m,m, 1.0d0,wsp(iget),m, wsp(iget),m,
+     .                0.0d0,wsp(iput),m )
+         iodd = 1-iodd
+      enddo
+ 200  continue
+      iexph = iput
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine DSPADM( ideg,m,t,H,ldh,wsp,lwsp,ipiv,iexph,ns,iflag )
+
+      implicit none
+      integer ideg, m, ldh, lwsp, iexph, ns, iflag, ipiv(m)
+      double precision t, H(ldh,m), wsp(lwsp)
+
+*-----Purpose----------------------------------------------------------|
+*
+*     Computes exp(t*H), the matrix exponential of a symmetric matrix
+*     in full, using the irreducible rational Pade approximation to the 
+*     exponential function exp(x) = r(x) = (+/-)( I + 2*(q(x)/p(x)) ),
+*     combined with scaling-and-squaring.
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     ideg      : (input) the degre of the diagonal Pade to be used.
+*                 a value of 6 is generally satisfactory.
+*
+*     m         : (input) order of H.
+*
+*     H(ldh,m)  : (input) argument matrix (both lower and upper parts).
+*
+*     t         : (input) time-scale (can be < 0).
+*                  
+*     wsp(lwsp) : (workspace/output) lwsp .ge. 4*m*m+ideg+1.
+*
+*     ipiv(m)   : (workspace)
+*
+*>>>> iexph     : (output) number such that wsp(iexph) points to exp(tH)
+*                 i.e., exp(tH) is located at wsp(iexph ... iexph+m*m-1)
+*                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+*                 NOTE: if the routine was called with wsp(iptr), 
+*                       then exp(tH) will start at wsp(iptr+iexph-1).
+*
+*     ns        : (output) number of scaling-squaring used.
+*
+*     iflag     : (output) exit flag.
+*                      0 - no problem
+*                     <0 - problem
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      integer mm,i,j,k,ih2,ip,iq,iused,ifree,iodd,icoef,iput,iget
+      double precision hnorm,scale,scale2,cp,cq
+
+      intrinsic INT,ABS,DBLE,LOG,MAX
+
+*---  check restrictions on input parameters ...
+      mm = m*m
+      iflag = 0
+      if ( ldh.lt.m ) iflag = -1
+      if ( lwsp.lt.4*mm+ideg+1 ) iflag = -2
+      if ( iflag.ne.0 ) stop 'bad sizes (in input of DSPADM)'
+*
+*---  initialise pointers ...
+*
+      icoef = 1
+      ih2 = icoef + (ideg+1)
+      ip  = ih2 + mm
+      iq  = ip + mm
+      ifree = iq + mm
+*
+*---  scaling: seek ns such that ||t*H/2^ns|| < 1/2; 
+*     and set scale = t/2^ns ...
+*
+      do i = 1,m
+         wsp(i) = 0.0d0
+      enddo
+      do j = 1,m
+         do i = 1,m
+            wsp(i) = wsp(i) + ABS( H(i,j) )
+         enddo
+      enddo
+      hnorm = 0.0d0
+      do i = 1,m
+         hnorm = MAX( hnorm,wsp(i) )
+      enddo
+      hnorm = ABS( t*hnorm )
+      if ( hnorm.eq.0.0d0 ) stop 'Error - null H in input of DSPADM.'
+      ns = MAX( 0,INT(LOG(hnorm)/LOG(2.0d0))+2 )
+      scale = t / DBLE(2**ns)
+      scale2 = scale*scale
+*
+*---  compute Pade coefficients ...
+*
+      i = ideg+1
+      j = 2*ideg+1
+      wsp(icoef) = 1.0d0
+      do k = 1,ideg
+         wsp(icoef+k) = (wsp(icoef+k-1)*DBLE( i-k ))/DBLE( k*(j-k) )
+      enddo
+*
+*---  H2 = scale2*H*H ...
+*
+      call DGEMM( 'n','n',m,m,m,scale2,H,ldh,H,ldh,0.0d0,wsp(ih2),m )
+*
+*---  initialize p (numerator) and q (denominator) ...
+*
+      cp = wsp(icoef+ideg-1)
+      cq = wsp(icoef+ideg)
+      do j = 1,m
+         do i = 1,m
+            wsp(ip + (j-1)*m + i-1) = 0.0d0
+            wsp(iq + (j-1)*m + i-1) = 0.0d0
+         enddo
+         wsp(ip + (j-1)*(m+1)) = cp
+         wsp(iq + (j-1)*(m+1)) = cq
+      enddo
+*
+*---  Apply Horner rule ...
+*
+      iodd = 1
+      k = ideg - 1
+ 100  continue
+      iused = iodd*iq + (1-iodd)*ip
+      call DGEMM( 'n','n',m,m,m, 1.0d0,wsp(iused),m,
+     .             wsp(ih2),m, 0.0d0,wsp(ifree),m )
+      do j = 1,m
+         wsp(ifree+(j-1)*(m+1)) = wsp(ifree+(j-1)*(m+1))+wsp(icoef+k-1)
+      enddo
+      ip = (1-iodd)*ifree + iodd*ip
+      iq = iodd*ifree + (1-iodd)*iq
+      ifree = iused
+      iodd = 1-iodd
+      k = k-1
+      if ( k.gt.0 )  goto 100
+*
+*---  Obtain (+/-)(I + 2*(p\q)) ...
+*
+      if ( iodd .eq. 1 ) then
+         call DGEMM( 'n','n',m,m,m, scale,wsp(iq),m,
+     .                H,ldh, 0.0d0,wsp(ifree),m )
+         iq = ifree
+      else
+         call DGEMM( 'n','n',m,m,m, scale,wsp(ip),m,
+     .                H,ldh, 0.0d0,wsp(ifree),m )
+         ip = ifree
+      endif
+      call DAXPY( mm, -1.0d0,wsp(ip),1, wsp(iq),1 )
+      call DSYSV( 'U',m,m,wsp(iq),m,ipiv,wsp(ip),m,wsp(ih2),mm,iflag )
+      if ( iflag.ne.0 ) stop 'Problem in DSYSV (within DSPADM)'
+      call DSCAL( mm, 2.0d0, wsp(ip), 1 )
+      do j = 1,m
+         wsp(ip+(j-1)*(m+1)) = wsp(ip+(j-1)*(m+1)) + 1.0d0
+      enddo
+      iput = ip
+      if ( ns.eq.0 .and. iodd.eq.1 ) then
+         call DSCAL( mm, -1.0d0, wsp(ip), 1 )
+         goto 200
+      endif
+*
+*--   squaring : exp(t*H) = (exp(t*H))^(2^ns) ...
+*
+      iodd = 1
+      do k = 1,ns
+         iget = iodd*ip + (1-iodd)*iq
+         iput = (1-iodd)*ip + iodd*iq
+         call DGEMM( 'n','n',m,m,m, 1.0d0,wsp(iget),m, wsp(iget),m,
+     .                0.0d0,wsp(iput),m )
+         iodd = 1-iodd
+      enddo
+ 200  continue
+      iexph = iput
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine ZGPADM(ideg,m,t,H,ldh,wsp,lwsp,ipiv,iexph,ns,iflag)
+
+      implicit none
+      double precision t
+      integer          ideg, m, ldh, lwsp, iexph, ns, iflag, ipiv(m)
+      complex*16       H(ldh,m), wsp(lwsp)
+
+*-----Purpose----------------------------------------------------------|
+*
+*     Computes exp(t*H), the matrix exponential of a general complex 
+*     matrix in full, using the irreducible rational Pade approximation
+*     to the exponential exp(z) = r(z) = (+/-)( I + 2*(q(z)/p(z)) ),
+*     combined with scaling-and-squaring.
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     ideg      : (input) the degre of the diagonal Pade to be used.
+*                 a value of 6 is generally satisfactory.
+*
+*     m         : (input) order of H.
+*
+*     H(ldh,m)  : (input) argument matrix.
+*
+*     t         : (input) time-scale (can be < 0).
+*                  
+*     wsp(lwsp) : (workspace/output) lwsp .ge. 4*m*m+ideg+1.
+*
+*     ipiv(m)   : (workspace)
+*
+*>>>> iexph     : (output) number such that wsp(iexph) points to exp(tH)
+*                 i.e., exp(tH) is located at wsp(iexph ... iexph+m*m-1)
+*                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+*                 NOTE: if the routine was called with wsp(iptr), 
+*                       then exp(tH) will start at wsp(iptr+iexph-1).
+*
+*     ns        : (output) number of scaling-squaring used.
+*
+*     iflag     : (output) exit flag.
+*                       0 - no problem
+*                      <0 - problem
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      integer i,j,k,icoef,mm,ih2,iodd,iused,ifree,iq,ip,iput,iget
+      double precision hnorm
+      complex*16 cp, cq, scale, scale2, ZERO, ONE
+
+      parameter( ZERO=(0.0d0,0.0d0), ONE=(1.0d0,0.0d0) )
+      intrinsic ABS, CMPLX, DBLE, INT, LOG, MAX
+      
+*---  check restrictions on input parameters ...
+      mm = m*m
+      iflag = 0
+      if ( ldh.lt.m ) iflag = -1
+      if ( lwsp.lt.4*mm+ideg+1 ) iflag = -2
+      if ( iflag.ne.0 ) stop 'bad sizes (in input of ZGPADM)'
+*
+*---  initialise pointers ...
+*
+      icoef = 1
+      ih2 = icoef + (ideg+1)
+      ip  = ih2 + mm
+      iq  = ip + mm
+      ifree = iq + mm
+*
+*---  scaling: seek ns such that ||t*H/2^ns|| < 1/2; 
+*     and set scale = t/2^ns ...
+*
+      do i = 1,m
+         wsp(i) = ZERO
+      enddo
+      do j = 1,m
+         do i = 1,m
+            wsp(i) = wsp(i) + ABS( H(i,j) )
+         enddo
+      enddo
+      hnorm = 0.0d0
+      do i = 1,m
+         hnorm = MAX( hnorm,DBLE(wsp(i)) )
+      enddo
+      hnorm = ABS( t*hnorm )
+      if ( hnorm.eq.0.0d0 ) stop 'Error - null H in input of ZGPADM.'
+      ns = MAX( 0,INT(LOG(hnorm)/LOG(2.0d0))+2 )
+!      scale =  CMPLX( t/DBLE(2**ns),0.0d0 )  ! for debug;
+      scale =  DCMPLX( t/DBLE(2**ns),0.0d0 )
+      scale2 = scale*scale
+*
+*---  compute Pade coefficients ...
+*
+      i = ideg+1
+      j = 2*ideg+1
+      wsp(icoef) = ONE
+      do k = 1,ideg
+         wsp(icoef+k) = (wsp(icoef+k-1)*DBLE( i-k ))/DBLE( k*(j-k) )
+      enddo
+*
+*---  H2 = scale2*H*H ...
+*
+      call ZGEMM( 'n','n',m,m,m,scale2,H,ldh,H,ldh,ZERO,wsp(ih2),m )
+*
+*---  initialise p (numerator) and q (denominator) ...
+*
+      cp = wsp(icoef+ideg-1)
+      cq = wsp(icoef+ideg)
+      do j = 1,m
+         do i = 1,m
+            wsp(ip + (j-1)*m + i-1) = ZERO
+            wsp(iq + (j-1)*m + i-1) = ZERO
+         enddo
+         wsp(ip + (j-1)*(m+1)) = cp
+         wsp(iq + (j-1)*(m+1)) = cq
+      enddo
+*
+*---  Apply Horner rule ...
+*
+      iodd = 1
+      k = ideg - 1
+ 100  continue
+      iused = iodd*iq + (1-iodd)*ip
+      call ZGEMM( 'n','n',m,m,m, ONE,wsp(iused),m,
+     .             wsp(ih2),m, ZERO,wsp(ifree),m )
+      do j = 1,m
+         wsp(ifree+(j-1)*(m+1)) = wsp(ifree+(j-1)*(m+1))+wsp(icoef+k-1)
+      enddo
+      ip = (1-iodd)*ifree + iodd*ip
+      iq = iodd*ifree + (1-iodd)*iq
+      ifree = iused
+      iodd = 1-iodd
+      k = k-1
+      if ( k.gt.0 )  goto 100
+*
+*---  Obtain (+/-)(I + 2*(p\q)) ...
+*
+      if ( iodd.ne.0 ) then
+         call ZGEMM( 'n','n',m,m,m, scale,wsp(iq),m,
+     .                H,ldh, ZERO,wsp(ifree),m )
+         iq = ifree
+      else
+         call ZGEMM( 'n','n',m,m,m, scale,wsp(ip),m,
+     .                H,ldh, ZERO,wsp(ifree),m )
+         ip = ifree
+      endif
+      call ZAXPY( mm, -ONE,wsp(ip),1, wsp(iq),1 )
+      call ZGESV( m,m, wsp(iq),m, ipiv, wsp(ip),m, iflag )
+      if ( iflag.ne.0 ) stop 'Problem in ZGESV (within ZGPADM)'
+      call ZDSCAL( mm, 2.0d0, wsp(ip), 1 )
+      do j = 1,m
+         wsp(ip+(j-1)*(m+1)) = wsp(ip+(j-1)*(m+1)) + ONE
+      enddo
+      iput = ip
+      if ( ns.eq.0 .and. iodd.ne.0 ) then
+         call ZDSCAL( mm, -1.0d0, wsp(ip), 1 )
+         goto 200
+      endif
+*
+*--   squaring : exp(t*H) = (exp(t*H))^(2^ns) ...
+*
+      iodd = 1
+      do k = 1,ns
+         iget = iodd*ip + (1-iodd)*iq
+         iput = (1-iodd)*ip + iodd*iq
+         call ZGEMM( 'n','n',m,m,m, ONE,wsp(iget),m, wsp(iget),m,
+     .                ZERO,wsp(iput),m )
+         iodd = 1-iodd
+      enddo
+ 200  continue
+      iexph = iput
+      END
+*----------------------------------------------------------------------|
+      subroutine ZHPADM(ideg,m,t,H,ldh,wsp,lwsp,ipiv,iexph,ns,iflag)
+
+      implicit none
+      double precision t
+      integer          ideg, m, ldh, lwsp, iexph, ns, iflag, ipiv(m)
+      complex*16       H(ldh,m), wsp(lwsp)
+
+*-----Purpose----------------------------------------------------------|
+*
+*     Computes exp(t*H), the matrix exponential of an Hermitian matrix
+*     in full, using the irreducible rational Pade approximation to the
+*     exponential function exp(z) = r(z) = (+/-)( I + 2*(q(z)/p(z)) ),
+*     combined with scaling-and-squaring.
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     ideg      : (input) the degre of the diagonal Pade to be used.
+*                 a value of 6 is generally satisfactory.
+*
+*     m         : (input) order of H.
+*
+*     H(ldh,m)  : (input) argument matrix (both lower and upper parts).
+*
+*     t         : (input) time-scale (can be < 0).
+*                  
+*     wsp(lwsp) : (workspace/output) lwsp .ge. 4*m*m+ideg+1.
+*
+*     ipiv(m)   : (workspace)
+*
+*>>>> iexph     : (output) number such that wsp(iexph) points to exp(tH)
+*                 i.e., exp(tH) is located at wsp(iexph ... iexph+m*m-1)
+*                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+*                 NOTE: if the routine was called with wsp(iptr), 
+*                       then exp(tH) will start at wsp(iptr+iexph-1).
+*
+*     ns        : (output) number of scaling-squaring used.
+*
+*     iflag     : (output) exit flag.
+*                       0 - no problem
+*                      <0 - problem
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      integer i,j,k,icoef,mm,ih2,iodd,iused,ifree,iq,ip,iput,iget
+      double precision hnorm
+      complex*16 cp, cq, scale, scale2, ZERO, ONE
+
+      parameter( ZERO=(0.0d0,0.0d0), ONE=(1.0d0,0.0d0) )
+      intrinsic ABS, CMPLX, DBLE, INT, LOG, MAX
+
+*---  check restrictions on input parameters ...
+      mm = m*m
+      iflag = 0
+      if ( ldh.lt.m ) iflag = -1
+      if ( lwsp.lt.4*mm+ideg+1 ) iflag = -2
+      if ( iflag.ne.0 ) stop 'bad sizes (in input of ZHPADM)'
+*
+*---  initialise pointers ...
+*
+      icoef = 1
+      ih2 = icoef + (ideg+1)
+      ip  = ih2 + mm
+      iq  = ip + mm
+      ifree = iq + mm
+*
+*---  scaling: seek ns such that ||t*H/2^ns|| < 1/2; 
+*     and set scale = t/2^ns ...
+*
+      do i = 1,m
+         wsp(i) = ZERO
+      enddo
+      do j = 1,m
+         do i = 1,m
+            wsp(i) = wsp(i) + ABS( H(i,j) )
+         enddo
+      enddo
+      hnorm = 0.0d0
+      do i = 1,m
+         hnorm = MAX( hnorm,DBLE(wsp(i)) )
+      enddo
+      hnorm = ABS( t*hnorm )
+      if ( hnorm.eq.0.0d0 ) stop 'Error - null H in input of ZHPADM.'
+      ns = MAX( 0,INT(LOG(hnorm)/LOG(2.0d0))+2 )
+      scale =  CMPLX( t/DBLE(2**ns),0.0d0 )
+      scale2 = scale*scale
+*
+*---  compute Pade coefficients ...
+*
+      i = ideg+1
+      j = 2*ideg+1
+      wsp(icoef) = ONE
+      do k = 1,ideg
+         wsp(icoef+k) = (wsp(icoef+k-1)*DBLE( i-k ))/DBLE( k*(j-k) )
+      enddo
+*
+*---  H2 = scale2*H*H ...
+*
+      call ZGEMM( 'n','n',m,m,m,scale2,H,ldh,H,ldh,ZERO,wsp(ih2),m )
+*
+*---  initialise p (numerator) and q (denominator) ...
+*
+      cp = wsp(icoef+ideg-1)
+      cq = wsp(icoef+ideg)
+      do j = 1,m
+         do i = 1,m
+            wsp(ip + (j-1)*m + i-1) = ZERO
+            wsp(iq + (j-1)*m + i-1) = ZERO
+         enddo
+         wsp(ip + (j-1)*(m+1)) = cp
+         wsp(iq + (j-1)*(m+1)) = cq
+      enddo
+*
+*---  Apply Horner rule ...
+*
+      iodd = 1
+      k = ideg - 1
+ 100  continue
+      iused = iodd*iq + (1-iodd)*ip
+      call ZGEMM( 'n','n',m,m,m, ONE,wsp(iused),m,
+     .             wsp(ih2),m, ZERO,wsp(ifree),m )
+      do j = 1,m
+         wsp(ifree+(j-1)*(m+1)) = wsp(ifree+(j-1)*(m+1))+wsp(icoef+k-1)
+      enddo
+      ip = (1-iodd)*ifree + iodd*ip
+      iq = iodd*ifree + (1-iodd)*iq
+      ifree = iused
+      iodd = 1-iodd
+      k = k-1
+      if ( k.gt.0 )  goto 100
+*
+*---  Obtain (+/-)(I + 2*(p\q)) ...
+*
+      if ( iodd.ne.0 ) then
+         call ZGEMM( 'n','n',m,m,m, scale,wsp(iq),m,
+     .                H,ldh, ZERO,wsp(ifree),m )
+         iq = ifree
+      else
+         call ZGEMM( 'n','n',m,m,m, scale,wsp(ip),m,
+     .                H,ldh, ZERO,wsp(ifree),m )
+         ip = ifree
+      endif
+      call ZAXPY( mm, -ONE,wsp(ip),1, wsp(iq),1 )
+      call ZHESV( 'U',m,m,wsp(iq),m,ipiv,wsp(ip),m,wsp(ih2),mm,iflag )
+      if ( iflag.ne.0 ) stop 'Problem in ZHESV (within ZHPADM)'
+      call ZDSCAL( mm, 2.0d0, wsp(ip), 1 )
+      do j = 1,m
+         wsp(ip+(j-1)*(m+1)) = wsp(ip+(j-1)*(m+1)) + ONE
+      enddo
+      iput = ip
+      if ( ns.eq.0 .and. iodd.ne.0 ) then
+         call ZDSCAL( mm, -1.0d0, wsp(ip), 1 )
+         goto 200
+      endif
+*
+*--   squaring : exp(t*H) = (exp(t*H))^(2^ns) ...
+*
+      iodd = 1
+      do k = 1,ns
+         iget = iodd*ip + (1-iodd)*iq
+         iput = (1-iodd)*ip + iodd*iq
+         call ZGEMM( 'n','n',m,m,m, ONE,wsp(iget),m, wsp(iget),m,
+     .                ZERO,wsp(iput),m )
+         iodd = 1-iodd
+      enddo
+ 200  continue
+      iexph = iput
+      END
+*----------------------------------------------------------------------|
+      subroutine DGCHBV( m, t, H,ldh, y, wsp, iwsp, iflag )
+
+      implicit none
+      integer          m, ldh, iflag, iwsp(m)
+      double precision t, H(ldh,m), y(m)
+      complex*16       wsp(m*(m+2))
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  DGCHBV computes y = exp(t*H)*y using the partial fraction
+*     expansion of the uniform rational Chebyshev approximation
+*     to exp(-x) of type (14,14). H is a General matrix.
+*     About 14-digit accuracy is expected if the matrix H is negative
+*     definite. The algorithm may behave poorly otherwise. 
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     m       : (input) order of the matrix H
+*
+*     t       : (input) time-scaling factor (can be < 0).
+*
+*     H(ldh,m): (input) argument matrix.
+*
+*     y(m)    : (input/output) on input the operand vector,
+*               on output the resulting vector exp(t*H)*y.
+*
+*     iwsp(m) : (workspace)
+*
+*     wsp     : (workspace). Observe that a double precision vector of
+*               length 2*m*(m+2) can be used as well when calling this
+*               routine (thus avoiding an idle complex array elsewhere)
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      integer ndeg, i, j, ip, ih, iy, iz
+      parameter ( ndeg=7 )
+      double precision alpha0
+      complex*16 alpha(ndeg), theta(ndeg)
+
+      intrinsic DBLE
+      
+*---  Pointers ...
+
+      ih = 1
+      iy = ih + m*m
+      iz = iy + m
+
+*---  Coefficients and poles of the partial fraction expansion ...
+
+      alpha0  =  0.183216998528140087D-11
+      alpha(1)=( 0.557503973136501826D+02,-0.204295038779771857D+03)
+      alpha(2)=(-0.938666838877006739D+02, 0.912874896775456363D+02)
+      alpha(3)=( 0.469965415550370835D+02,-0.116167609985818103D+02)
+      alpha(4)=(-0.961424200626061065D+01,-0.264195613880262669D+01)
+      alpha(5)=( 0.752722063978321642D+00, 0.670367365566377770D+00)
+      alpha(6)=(-0.188781253158648576D-01,-0.343696176445802414D-01)
+      alpha(7)=( 0.143086431411801849D-03, 0.287221133228814096D-03)
+
+      theta(1)=(-0.562314417475317895D+01, 0.119406921611247440D+01)
+      theta(2)=(-0.508934679728216110D+01, 0.358882439228376881D+01)
+      theta(3)=(-0.399337136365302569D+01, 0.600483209099604664D+01)
+      theta(4)=(-0.226978543095856366D+01, 0.846173881758693369D+01)
+      theta(5)=( 0.208756929753827868D+00, 0.109912615662209418D+02)
+      theta(6)=( 0.370327340957595652D+01, 0.136563731924991884D+02)
+      theta(7)=( 0.889777151877331107D+01, 0.166309842834712071D+02)
+*     
+*---  Accumulation of the contribution of each pole ...
+*
+      do j = 1,m
+         wsp(iz+j-1) = y(j)
+         y(j) = y(j)*alpha0
+      enddo
+      do ip = 1,ndeg
+*---     Solve each fraction using Gaussian elimination with pivoting...
+         do j = 1,m
+            do i = 1,m
+               wsp(ih+(j-1)*m+i-1) = -t*H(i,j)
+            enddo
+            wsp(ih+(j-1)*m+j-1) = wsp(ih+(j-1)*m+j-1)-theta(ip)
+            wsp(iy+j-1) = wsp(iz+j-1)
+         enddo
+         call ZGESV( M, 1, WSP(iH),M, IWSP, WSP(iY),M, IFLAG )
+         if ( IFLAG.ne.0 ) stop 'Error in DGCHBV'
+*---     Accumulate the partial result in y ...     
+         do j = 1,m
+            y(j) = y(j) + DBLE( alpha(ip)*wsp(iy+j-1) )
+         enddo
+      enddo
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine DSCHBV( m, t, H,ldh, y, wsp, iwsp, iflag )
+
+      implicit none
+      integer          m, ldh, iflag, iwsp(m)
+      double precision t, H(ldh,m), y(m)
+      complex*16       wsp(m*(m+2))
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  DSCHBV computes y = exp(t*H)*y using the partial fraction
+*     expansion of the uniform rational Chebyshev approximation
+*     to exp(-x) of type (14,14). H is assumed to be symmetric.
+*     About 14-digit accuracy is expected if the matrix H is negative
+*     definite. The algorithm may behave poorly otherwise. 
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     m       : (input) order of matrix H
+*
+*     t       : (input) time-scaling factor (can be < 0).
+*
+*     H(ldh,m): (input) symmetric matrix.
+*
+*     y(m)    : (input/output) on input the operand vector,
+*               on output the resulting vector exp(t*H)*y.
+*
+*     iwsp(m) : (workspace)
+*
+*     wsp     : (workspace). Observe that a double precision vector of
+*               length 2*m*(m+2) can be used as well when calling this
+*               routine (thus avoiding an idle complex array elsewhere)
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      integer ndeg, i, j, ip, ih, iy, iz
+      parameter ( ndeg=7 )
+      double precision alpha0
+      complex*16 alpha(ndeg), theta(ndeg), w
+
+      intrinsic ABS,CMPLX,DBLE,MIN
+      
+*---  Pointers ...
+
+      ih = 1
+      iy = ih + m*m
+      iz = iy + m
+
+*---  Coefficients and poles of the partial fraction expansion ...
+
+      alpha0  =  0.183216998528140087D-11
+      alpha(1)=( 0.557503973136501826D+02,-0.204295038779771857D+03)
+      alpha(2)=(-0.938666838877006739D+02, 0.912874896775456363D+02)
+      alpha(3)=( 0.469965415550370835D+02,-0.116167609985818103D+02)
+      alpha(4)=(-0.961424200626061065D+01,-0.264195613880262669D+01)
+      alpha(5)=( 0.752722063978321642D+00, 0.670367365566377770D+00)
+      alpha(6)=(-0.188781253158648576D-01,-0.343696176445802414D-01)
+      alpha(7)=( 0.143086431411801849D-03, 0.287221133228814096D-03)
+
+      theta(1)=(-0.562314417475317895D+01, 0.119406921611247440D+01)
+      theta(2)=(-0.508934679728216110D+01, 0.358882439228376881D+01)
+      theta(3)=(-0.399337136365302569D+01, 0.600483209099604664D+01)
+      theta(4)=(-0.226978543095856366D+01, 0.846173881758693369D+01)
+      theta(5)=( 0.208756929753827868D+00, 0.109912615662209418D+02)
+      theta(6)=( 0.370327340957595652D+01, 0.136563731924991884D+02)
+      theta(7)=( 0.889777151877331107D+01, 0.166309842834712071D+02)
+*     
+*---  Accumulation of the contribution of each pole ...
+*
+      do j = 1,m
+         wsp(iz+j-1) = y(j)
+         y(j) = y(j)*alpha0
+      enddo
+      do ip = 1,ndeg
+*---     Solve each fraction using Gaussian elimination with pivoting...
+         do j = 1,m
+            do i = 1,m
+               wsp(ih+(j-1)*m+i-1) = -t*H(i,j)
+            enddo
+            wsp(ih+(j-1)*m+j-1) = wsp(ih+(j-1)*m+j-1)-theta(ip)
+            wsp(iy+j-1) = wsp(iz+j-1)
+         enddo
+         call ZSYSV('U', M, 1, WSP(iH),M, IWSP, WSP(iY),M, W,1, IFLAG )
+         if ( IFLAG.ne.0 ) stop 'Error in DSCHBV'
+*---     Accumulate the partial result in y ...     
+         do i = 1,m
+            y(i) = y(i) + DBLE( alpha(ip)*wsp(iy+i-1) )
+         enddo
+      enddo
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine ZGCHBV( m, t, H,ldh, y, wsp, iwsp, iflag )
+
+      implicit none
+      integer          m, ldh, iflag, iwsp(m)
+      double precision t
+      complex*16       H(ldh,m), y(m), wsp(m*(m+2))
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  ZGCHBV computes y = exp(t*H)*y using the partial fraction
+*     expansion of the uniform rational Chebyshev approximation
+*     to exp(-x) of type (14,14). H is a General matrix.
+*     About 14-digit accuracy is expected if the matrix H is negative
+*     definite. The algorithm may behave poorly otherwise. 
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     m       : (input) order of the matrix H.
+*
+*     t       : (input) time-scaling factor (can be < 0).
+*
+*     H(ldh,m): (input) argument matrix.
+*
+*     y(m)    : (input/output) on input the operand vector,
+*               on output the resulting vector exp(t*H)*y.
+*
+*     iwsp(m) : (workspace)
+*
+*     wsp     : (workspace). Observe that a double precision vector of
+*               length 2*m*(m+2) can be used as well when calling this
+*               routine.
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      integer     ndeg, i, j, ip, ih, iy, iz
+      parameter ( ndeg=7 )
+      double      precision alpha0
+      complex*16  alpha(2*ndeg), theta(2*ndeg)
+      
+*---  Pointers ...
+
+      ih = 1
+      iy = ih + m*m
+      iz = iy + m
+
+*---  Coefficients and poles of the partial fraction expansion ...
+
+      alpha0  =  0.183216998528140087D-11
+      alpha(1)=( 0.557503973136501826D+02,-0.204295038779771857D+03)
+      alpha(2)=(-0.938666838877006739D+02, 0.912874896775456363D+02)
+      alpha(3)=( 0.469965415550370835D+02,-0.116167609985818103D+02)
+      alpha(4)=(-0.961424200626061065D+01,-0.264195613880262669D+01)
+      alpha(5)=( 0.752722063978321642D+00, 0.670367365566377770D+00)
+      alpha(6)=(-0.188781253158648576D-01,-0.343696176445802414D-01)
+      alpha(7)=( 0.143086431411801849D-03, 0.287221133228814096D-03)
+
+      theta(1)=(-0.562314417475317895D+01, 0.119406921611247440D+01)
+      theta(2)=(-0.508934679728216110D+01, 0.358882439228376881D+01)
+      theta(3)=(-0.399337136365302569D+01, 0.600483209099604664D+01)
+      theta(4)=(-0.226978543095856366D+01, 0.846173881758693369D+01)
+      theta(5)=( 0.208756929753827868D+00, 0.109912615662209418D+02)
+      theta(6)=( 0.370327340957595652D+01, 0.136563731924991884D+02)
+      theta(7)=( 0.889777151877331107D+01, 0.166309842834712071D+02)
+*
+      do ip = 1,ndeg
+         theta(ndeg+ip) = CONJG( theta(ip) )
+         alpha(ndeg+ip) = CONJG( alpha(ip) )
+      enddo
+*     
+*---  Accumulation of the contribution of each pole ...
+*
+      do j = 1,m
+         wsp(iz+j-1) = y(j)
+         y(j) = y(j)*alpha0
+      enddo
+      do ip = 1,2*ndeg
+         alpha(ip) = 0.5d0*alpha(ip)
+*---     Solve each fraction using Gaussian elimination with pivoting...
+         do j = 1,m
+            do i = 1,m
+               wsp(ih+(j-1)*m+i-1) = -t*H(i,j)
+            enddo
+            wsp(ih+(j-1)*m+j-1) = wsp(ih+(j-1)*m+j-1)-theta(ip)
+            wsp(iy+j-1) = wsp(iz+j-1)
+         enddo
+         call ZGESV( M, 1, WSP(iH),M, IWSP, WSP(iY),M, IFLAG )
+         if ( IFLAG.ne.0 ) stop 'Error in ZGCHBV'
+*---     Accumulate the partial result in y ...     
+         do i = 1,m
+            y(i) = y(i) + alpha(ip)*wsp(iy+i-1)
+         enddo
+      enddo
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine DNCHBV( m, t, H,ldh, y, wsp )
+
+      implicit none
+      integer          m, ldh
+      double precision t, H(ldh,m), y(m)
+      complex*16       wsp(m*(m+2))
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  DNCHBV computes y = exp(t*H)*y using the partial fraction
+*     expansion of the uniform rational Chebyshev approximation
+*     to exp(-x) of type (14,14). H is assumed to be upper-Hessenberg.
+*     About 14-digit accuracy is expected if the matrix H is negative
+*     definite. The algorithm may behave poorly otherwise. 
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     m       : (input) order of the Hessenberg matrix H
+*
+*     t       : (input) time-scaling factor (can be < 0).
+*
+*     H(ldh,m): (input) upper Hessenberg matrix.
+*
+*     y(m)    : (input/output) on input the operand vector,
+*               on output the resulting vector exp(t*H)*y.
+*
+*     wsp     : (workspace). Observe that a double precision vector of
+*               length 2*m*(m+2) can be used as well when calling this
+*               routine (thus avoiding an idle complex array elsewhere)
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      complex*16 ZERO
+      integer ndeg, i, j, k, ip, ih, iy, iz
+      parameter ( ndeg=7, ZERO=(0.0d0,0.0d0) )
+      double precision alpha0
+      complex*16 alpha(ndeg), theta(ndeg), tmpc
+
+      intrinsic ABS,DBLE,MIN
+      
+*---  Pointers ...
+
+      ih = 1
+      iy = ih + m*m
+      iz = iy + m
+
+*---  Coefficients and poles of the partial fraction expansion...
+
+      alpha0  =  0.183216998528140087D-11
+      alpha(1)=( 0.557503973136501826D+02,-0.204295038779771857D+03)
+      alpha(2)=(-0.938666838877006739D+02, 0.912874896775456363D+02)
+      alpha(3)=( 0.469965415550370835D+02,-0.116167609985818103D+02)
+      alpha(4)=(-0.961424200626061065D+01,-0.264195613880262669D+01)
+      alpha(5)=( 0.752722063978321642D+00, 0.670367365566377770D+00)
+      alpha(6)=(-0.188781253158648576D-01,-0.343696176445802414D-01)
+      alpha(7)=( 0.143086431411801849D-03, 0.287221133228814096D-03)
+
+      theta(1)=(-0.562314417475317895D+01, 0.119406921611247440D+01)
+      theta(2)=(-0.508934679728216110D+01, 0.358882439228376881D+01)
+      theta(3)=(-0.399337136365302569D+01, 0.600483209099604664D+01)
+      theta(4)=(-0.226978543095856366D+01, 0.846173881758693369D+01)
+      theta(5)=( 0.208756929753827868D+00, 0.109912615662209418D+02)
+      theta(6)=( 0.370327340957595652D+01, 0.136563731924991884D+02)
+      theta(7)=( 0.889777151877331107D+01, 0.166309842834712071D+02)
+*     
+*---  Accumulation of the contribution of each pole ...
+*
+      do j = 1,m
+         wsp(iz+j-1) = y(j)
+         y(j) = y(j)*alpha0
+      enddo
+      do ip = 1,ndeg
+*---     Solve each fraction using Gaussian elimination with pivoting...
+         do j = 1,m
+            wsp(iy+j-1) = wsp(iz+j-1)
+            do i = 1,MIN( j+1,m )
+               wsp(ih+(j-1)*m+i-1) = -t*H(i,j)
+            enddo
+            wsp(ih+(j-1)*m+j-1) = wsp(ih+(j-1)*m+j-1)-theta(ip)
+            do k = i,m
+               wsp(ih+(j-1)*m+k-1) = ZERO
+            enddo
+         enddo
+         do i = 1,m-1
+*---        Get pivot and exchange rows ...
+            if (ABS(wsp(ih+(i-1)*m+i-1)).lt.ABS(wsp(ih+(i-1)*m+i))) then
+               call ZSWAP( m-i+1, wsp(ih+(i-1)*m+i-1),m, 
+     .                     wsp(ih+(i-1)*m+i),m )
+               call ZSWAP( 1, wsp(iy+i-1),1, wsp(iy+i),1 )
+            endif
+*---        Forward eliminiation ... 
+            tmpc = wsp(ih+(i-1)*m+i) / wsp(ih+(i-1)*m+i-1)
+            call ZAXPY( m-i, -tmpc, wsp(ih+i*m+i-1),m, wsp(ih+i*m+i),m )
+            wsp(iy+i) = wsp(iy+i) - tmpc*wsp(iy+i-1)
+         enddo
+*---     Backward substitution ...    
+         do i = m,1,-1
+            tmpc = wsp(iy+i-1)
+            do j = i+1,m
+               tmpc = tmpc - wsp(ih+(j-1)*m+i-1)*wsp(iy+j-1)
+            enddo
+            wsp(iy+i-1) = tmpc / wsp(ih+(i-1)*m+i-1)
+         enddo
+*---     Accumulate the partial result in y ...     
+         do j = 1,m
+            y(j) = y(j) + DBLE( alpha(ip)*wsp(iy+j-1) )
+         enddo
+      enddo
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine ZNCHBV( m, t, H,ldh, y, wsp )
+
+      implicit none
+      integer          m, ldh
+      double precision t
+      complex*16       H(ldh,m), y(m), wsp(m*(m+2))
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  ZNCHBV computes y = exp(t*H)*y using the partial fraction
+*     expansion of the uniform rational Chebyshev approximation
+*     to exp(-x) of type (14,14). H is assumed to be upper-Hessenberg.
+*     About 14-digit accuracy is expected if the matrix H is negative
+*     definite. The algorithm may behave poorly otherwise. 
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     m       : (input) order of the Hessenberg matrix H
+*
+*     t       : (input) time-scaling factor (can be < 0).
+*
+*     H(ldh,m): (input) upper Hessenberg matrix.
+*
+*     y(m)    : (input/output) on input the operand vector,
+*               on output the resulting vector exp(t*H)*y.
+*
+*     wsp     : (workspace). Observe that a double precision vector of
+*               length 2*m*(m+2) can be used as well when calling this
+*               routine.
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      complex*16 ZERO
+      integer ndeg, i, j, k, ip, ih, iy, iz
+      parameter ( ndeg=7, ZERO=(0.0d0,0.0d0) )
+      double precision alpha0
+      complex*16 alpha(ndeg), theta(ndeg), tmpc
+
+      intrinsic ABS,DBLE,CONJG,MIN
+      
+*---  Pointers ...
+
+      ih = 1
+      iy = ih + m*m
+      iz = iy + m
+
+*---  Coefficients and poles of the partial fraction expansion...
+
+      alpha0  =  0.183216998528140087D-11
+      alpha(1)=( 0.557503973136501826D+02,-0.204295038779771857D+03)
+      alpha(2)=(-0.938666838877006739D+02, 0.912874896775456363D+02)
+      alpha(3)=( 0.469965415550370835D+02,-0.116167609985818103D+02)
+      alpha(4)=(-0.961424200626061065D+01,-0.264195613880262669D+01)
+      alpha(5)=( 0.752722063978321642D+00, 0.670367365566377770D+00)
+      alpha(6)=(-0.188781253158648576D-01,-0.343696176445802414D-01)
+      alpha(7)=( 0.143086431411801849D-03, 0.287221133228814096D-03)
+
+      theta(1)=(-0.562314417475317895D+01, 0.119406921611247440D+01)
+      theta(2)=(-0.508934679728216110D+01, 0.358882439228376881D+01)
+      theta(3)=(-0.399337136365302569D+01, 0.600483209099604664D+01)
+      theta(4)=(-0.226978543095856366D+01, 0.846173881758693369D+01)
+      theta(5)=( 0.208756929753827868D+00, 0.109912615662209418D+02)
+      theta(6)=( 0.370327340957595652D+01, 0.136563731924991884D+02)
+      theta(7)=( 0.889777151877331107D+01, 0.166309842834712071D+02)
+*
+      do ip = 1,ndeg
+         theta(ndeg+ip) = CONJG( theta(ip) )
+         alpha(ndeg+ip) = CONJG( alpha(ip) )
+      enddo
+*     
+*---  Accumulation of the contribution of each pole ...
+*
+      do j = 1,m
+         wsp(iz+j-1) = y(j)
+         y(j) = y(j)*alpha0
+      enddo
+      do ip = 1,2*ndeg
+         alpha(ip) = 0.5d0*alpha(ip)
+*---     Solve each fraction using Gaussian elimination with pivoting...
+         do j = 1,m
+            wsp(iy+j-1) = wsp(iz+j-1)
+            do i = 1,MIN( j+1,m )
+               wsp(ih+(j-1)*m+i-1) = -t*H(i,j)
+            enddo
+            wsp(ih+(j-1)*m+j-1) = wsp(ih+(j-1)*m+j-1)-theta(ip)
+            do k = i,m
+               wsp(ih+(j-1)*m+k-1) = ZERO
+            enddo
+         enddo
+         do i = 1,m-1
+*---        Get pivot and exchange rows ...
+            if (ABS(wsp(ih+(i-1)*m+i-1)).lt.ABS(wsp(ih+(i-1)*m+i))) then
+               call ZSWAP( m-i+1, wsp(ih+(i-1)*m+i-1),m, 
+     .                     wsp(ih+(i-1)*m+i),m )
+               call ZSWAP( 1, wsp(iy+i-1),1, wsp(iy+i),1 )
+            endif
+*---        Forward eliminiation ... 
+            tmpc = wsp(ih+(i-1)*m+i) / wsp(ih+(i-1)*m+i-1)
+            call ZAXPY( m-i, -tmpc, wsp(ih+i*m+i-1),m, wsp(ih+i*m+i),m )
+            wsp(iy+i) = wsp(iy+i) - tmpc*wsp(iy+i-1)
+         enddo
+*---     Backward substitution ...    
+         do i = m,1,-1
+            tmpc = wsp(iy+i-1)
+            do j = i+1,m
+               tmpc = tmpc - wsp(ih+(j-1)*m+i-1)*wsp(iy+j-1)
+            enddo
+            wsp(iy+i-1) = tmpc / wsp(ih+(i-1)*m+i-1)
+         enddo
+*---     Accumulate the partial result in y ...     
+         do j = 1,m
+            y(j) = y(j) + alpha(ip)*wsp(iy+j-1)
+         enddo
+      enddo
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine DGEXPV( n, m, t, v, w, tol, anorm,
+     .                   wsp,lwsp, iwsp,liwsp, matvec, itrace,iflag )
+
+      implicit none
+      integer n, m, lwsp, liwsp, itrace, iflag, iwsp(liwsp)
+      double precision t, tol, anorm, v(n), w(n), wsp(lwsp)
+      external matvec
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  DGEXPV computes w = exp(t*A)*v - for a General matrix A.
+*
+*     It does not compute the matrix exponential in isolation but
+*     instead, it computes directly the action of the exponential
+*     operator on the operand vector. This way of doing so allows 
+*     for addressing large sparse problems. 
+*
+*     The method used is based on Krylov subspace projection
+*     techniques and the matrix under consideration interacts only
+*     via the external routine `matvec' performing the matrix-vector 
+*     product (matrix-free method).
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     n      : (input) order of the principal matrix A.
+*                      
+*     m      : (input) maximum size for the Krylov basis.
+*                      
+*     t      : (input) time at wich the solution is needed (can be < 0).
+*                      
+*     v(n)   : (input) given operand vector.
+*                      
+*     w(n)   : (output) computed approximation of exp(t*A)*v.
+*
+*     tol    : (input/output) the requested accuracy tolerance on w. 
+*              If on input tol=0.0d0 or tol is too small (tol.le.eps)
+*              the internal value sqrt(eps) is used, and tol is set to
+*              sqrt(eps) on output (`eps' denotes the machine epsilon).
+*              (`Happy breakdown' is assumed if h(j+1,j) .le. anorm*tol)
+*
+*     anorm  : (input) an approximation of some norm of A.
+*
+*   wsp(lwsp): (workspace) lwsp .ge. n*(m+1)+n+(m+2)^2+4*(m+2)^2+ideg+1
+*                                   +---------+-------+---------------+
+*              (actually, ideg=6)        V        H      wsp for PADE
+*                   
+* iwsp(liwsp): (workspace) liwsp .ge. m+2
+*
+*     matvec : external subroutine for matrix-vector multiplication.
+*              synopsis: matvec( x, y )
+*                        double precision x(*), y(*)
+*              computes: y(1:n) <- A*x(1:n)
+*                        where A is the principal matrix.
+*
+*     itrace : (input) running mode. 0=silent, 1=print step-by-step info
+*
+*     iflag  : (output) exit flag.
+*              <0 - bad input arguments 
+*               0 - no problem
+*               1 - maximum number of steps reached without convergence
+*               2 - requested tolerance was too high
+*
+*-----Accounts on the computation--------------------------------------|
+*     Upon exit, an interested user may retrieve accounts on the 
+*     computations. They are located in wsp and iwsp as indicated below:
+*
+*     location  mnemonic                 description
+*     -----------------------------------------------------------------|
+*     iwsp(1) = nmult, number of matrix-vector multiplications used
+*     iwsp(2) = nexph, number of Hessenberg matrix exponential evaluated
+*     iwsp(3) = nscale, number of repeated squaring involved in Pade
+*     iwsp(4) = nstep, number of integration steps used up to completion 
+*     iwsp(5) = nreject, number of rejected step-sizes
+*     iwsp(6) = ibrkflag, set to 1 if `happy breakdown' and 0 otherwise
+*     iwsp(7) = mbrkdwn, if `happy brkdown', basis-size when it occured
+*     -----------------------------------------------------------------|
+*     wsp(1)  = step_min, minimum step-size used during integration
+*     wsp(2)  = step_max, maximum step-size used during integration
+*     wsp(3)  = dummy
+*     wsp(4)  = dummy
+*     wsp(5)  = x_error, maximum among all local truncation errors
+*     wsp(6)  = s_error, global sum of local truncation errors
+*     wsp(7)  = tbrkdwn, if `happy breakdown', time when it occured
+*     wsp(8)  = t_now, integration domain successfully covered
+*     wsp(9)  = hump, i.e., max||exp(sA)||, s in [0,t] (or [t,0] if t<0)
+*     wsp(10) = ||w||/||v||, scaled norm of the solution w.
+*     -----------------------------------------------------------------|
+*     The `hump' is a measure of the conditioning of the problem. The
+*     matrix exponential is well-conditioned if hump = 1, whereas it is
+*     poorly-conditioned if hump >> 1. However the solution can still be
+*     relatively fairly accurate even when the hump is large (the hump 
+*     is an upper bound), especially when the hump and the scaled norm
+*     of w [this is also computed and returned in wsp(10)] are of the 
+*     same order of magnitude (further details in reference below).
+*
+*----------------------------------------------------------------------|
+*-----The following parameters may also be adjusted herein-------------|
+*
+      integer mxstep, mxreject, ideg
+      double precision delta, gamma
+      parameter( mxstep   = 1000,
+     .           mxreject = 0,
+     .           ideg     = 6,
+     .           delta    = 1.2d0,
+     .           gamma    = 0.9d0 )
+
+*     mxstep  : maximum allowable number of integration steps.
+*               The value 0 means an infinite number of steps.
+* 
+*     mxreject: maximum allowable number of rejections at each step. 
+*               The value 0 means an infinite number of rejections.
+*
+*     ideg    : the Pade approximation of type (ideg,ideg) is used as 
+*               an approximation to exp(H). The value 0 switches to the
+*               uniform rational Chebyshev approximation of type (14,14)
+*
+*     delta   : local truncation error `safety factor'
+*
+*     gamma   : stepsize `shrinking factor'
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      integer i, j, k1, mh, mx, iv, ih, j1v, ns, ifree, lfree, iexph,
+     .        ireject,ibrkflag,mbrkdwn, nmult, nreject, nexph, nscale,
+     .        nstep
+      double precision sgn, t_out, tbrkdwn, step_min,step_max, err_loc,
+     .                 s_error, x_error, t_now, t_new, t_step, t_old,
+     .                 xm, beta, break_tol, p1, p2, p3, eps, rndoff,
+     .                 vnorm, avnorm, hj1j, hij, hump, SQR1
+
+      intrinsic AINT,ABS,DBLE,LOG10,MAX,MIN,NINT,SIGN,SQRT
+      double precision DDOT, DNRM2
+
+*---  check restrictions on input parameters ...
+      iflag = 0
+      if ( lwsp.lt.n*(m+2)+5*(m+2)**2+ideg+1 ) iflag = -1
+      if ( liwsp.lt.m+2 ) iflag = -2
+      if ( m.ge.n .or. m.le.0 ) iflag = -3
+      if ( iflag.ne.0 ) stop 'bad sizes (in input of DGEXPV)'
+*
+*---  initialisations ...
+*
+      k1 = 2
+      mh = m + 2
+      iv = 1
+      ih = iv + n*(m+1) + n
+      ifree = ih + mh*mh
+      lfree = lwsp - ifree + 1
+
+      ibrkflag = 0
+      mbrkdwn  = m
+      nmult    = 0
+      nreject  = 0
+      nexph    = 0
+      nscale   = 0
+
+      t_out    = ABS( t )
+      tbrkdwn  = 0.0d0
+      step_min = t_out
+      step_max = 0.0d0
+      nstep    = 0
+      s_error  = 0.0d0
+      x_error  = 0.0d0
+      t_now    = 0.0d0
+      t_new    = 0.0d0
+
+      p1 = 4.0d0/3.0d0
+ 1    p2 = p1 - 1.0d0
+      p3 = p2 + p2 + p2
+      eps = ABS( p3-1.0d0 )
+      if ( eps.eq.0.0d0 ) go to 1
+      if ( tol.le.eps ) tol = SQRT( eps )
+      rndoff = eps*anorm
+
+      break_tol = 1.0d-7
+*>>>  break_tol = tol
+*>>>  break_tol = anorm*tol
+
+      sgn = SIGN( 1.0d0,t )
+      call DCOPY( n, v,1, w,1 )
+      beta = DNRM2( n, w,1 )
+      vnorm = beta
+      hump = beta 
+*
+*---  obtain the very first stepsize ...
+*
+      SQR1 = SQRT( 0.1d0 )
+      xm = 1.0d0/DBLE( m )
+      p1 = tol*(((m+1)/2.72D0)**(m+1))*SQRT(2.0D0*3.14D0*(m+1))
+      t_new = (1.0d0/anorm)*(p1/(4.0d0*beta*anorm))**xm
+      p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+      t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+*
+*---  step-by-step integration ...
+*
+ 100  if ( t_now.ge.t_out ) goto 500
+
+      nstep = nstep + 1
+      t_step = MIN( t_out-t_now, t_new )
+
+      p1 = 1.0d0/beta
+      do i = 1,n
+         wsp(iv + i-1) = p1*w(i)
+      enddo
+      do i = 1,mh*mh
+         wsp(ih+i-1) = 0.0d0
+      enddo
+*
+*---  Arnoldi loop ...
+*
+      j1v = iv + n
+      do 200 j = 1,m
+         nmult = nmult + 1
+         call matvec( wsp(j1v-n), wsp(j1v) )
+         do i = 1,j
+            hij = DDOT( n, wsp(iv+(i-1)*n),1, wsp(j1v),1 )
+            call DAXPY( n, -hij, wsp(iv+(i-1)*n),1, wsp(j1v),1 )
+            wsp(ih+(j-1)*mh+i-1) = hij
+         enddo
+         hj1j = DNRM2( n, wsp(j1v),1 )
+*---     if `happy breakdown' go straightforward at the end ... 
+         if ( hj1j.le.break_tol ) then
+            print*,'happy breakdown: mbrkdwn =',j,' h =',hj1j
+            k1 = 0
+            ibrkflag = 1
+            mbrkdwn = j
+            tbrkdwn = t_now
+            t_step = t_out-t_now
+            goto 300
+         endif
+         wsp(ih+(j-1)*mh+j) = hj1j
+         call DSCAL( n, 1.0d0/hj1j, wsp(j1v),1 )
+         j1v = j1v + n
+ 200  continue
+      nmult = nmult + 1
+      call matvec( wsp(j1v-n), wsp(j1v) )
+      avnorm = DNRM2( n, wsp(j1v),1 )
+*
+*---  set 1 for the 2-corrected scheme ...
+*
+ 300  continue
+      wsp(ih+m*mh+m+1) = 1.0d0
+*
+*---  loop while ireject<mxreject until the tolerance is reached ...
+*
+      ireject = 0
+ 401  continue
+
+*
+*---  compute w = beta*V*exp(t_step*H)*e1 ...
+*
+      nexph = nexph + 1
+      mx = mbrkdwn + k1
+      if ( ideg.ne.0 ) then
+*---     irreducible rational Pade approximation ...
+         call DGPADM( ideg, mx, sgn*t_step, wsp(ih),mh,
+     .                wsp(ifree),lfree, iwsp, iexph, ns, iflag )
+         iexph = ifree + iexph - 1
+         nscale = nscale + ns
+      else
+*---     uniform rational Chebyshev approximation ...
+         iexph = ifree
+         do i = 1,mx
+            wsp(iexph+i-1) = 0.0d0
+         enddo
+         wsp(iexph) = 1.0d0
+         call DNCHBV(mx,sgn*t_step,wsp(ih),mh,wsp(iexph),wsp(ifree+mx))
+      endif
+
+ 402  continue
+* 
+*---  error estimate ...
+*
+      if ( k1.eq.0 ) then
+         err_loc = tol
+      else
+         p1 = ABS( wsp(iexph+m) )   * beta
+         p2 = ABS( wsp(iexph+m+1) ) * beta * avnorm
+         if ( p1.gt.10.0d0*p2 ) then
+            err_loc = p2
+            xm = 1.0d0/DBLE( m )
+         elseif ( p1.gt.p2 ) then
+            err_loc = (p1*p2)/(p1-p2)
+            xm = 1.0d0/DBLE( m )
+         else
+            err_loc = p1
+            xm = 1.0d0/DBLE( m-1 )
+         endif
+      endif
+*
+*---  reject the step-size if the error is not acceptable ...
+*   
+      if ( (k1.ne.0) .and. (err_loc.gt.delta*t_step*tol) .and.
+     .     (mxreject.eq.0 .or. ireject.lt.mxreject) ) then
+         t_old = t_step
+         t_step = gamma * t_step * (t_step*tol/err_loc)**xm
+         p1 = 10.0d0**(NINT( LOG10( t_step )-SQR1 )-1)
+         t_step = AINT( t_step/p1 + 0.55d0 ) * p1
+         if ( itrace.ne.0 ) then
+            print*,'t_step =',t_old
+            print*,'err_loc =',err_loc
+            print*,'err_required =',delta*t_old*tol
+            print*,'stepsize rejected, stepping down to:',t_step
+         endif
+         ireject = ireject + 1
+         nreject = nreject + 1
+         if ( mxreject.ne.0 .and. ireject.gt.mxreject ) then
+            print*,"Failure in DGEXPV: ---"
+            print*,"The requested tolerance is too high."
+            Print*,"Rerun with a smaller value."
+            iflag = 2
+            return
+         endif
+         goto 401
+      endif
+*
+*---  now update w = beta*V*exp(t_step*H)*e1 and the hump ...
+*
+      mx = mbrkdwn + MAX( 0,k1-1 )
+      call DGEMV( 'n', n,mx,beta,wsp(iv),n,wsp(iexph),1,0.0d0,w,1 )
+      beta = DNRM2( n, w,1 )
+      hump = MAX( hump, beta )
+*
+*---  suggested value for the next stepsize ...
+*
+      t_new = gamma * t_step * (t_step*tol/err_loc)**xm
+      p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+      t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+
+      err_loc = MAX( err_loc,rndoff )
+*
+*---  update the time covered ...
+*
+      t_now = t_now + t_step
+*
+*---  display and keep some information ...
+*
+      if ( itrace.ne.0 ) then
+         print*,'integration',nstep,'---------------------------------'
+         print*,'scale-square =',ns
+         print*,'step_size =',t_step
+         print*,'err_loc   =',err_loc
+         print*,'next_step =',t_new
+      endif
+
+      step_min = MIN( step_min, t_step )
+      step_max = MAX( step_max, t_step )
+      s_error = s_error + err_loc
+      x_error = MAX( x_error, err_loc )
+
+      if ( mxstep.eq.0 .or. nstep.lt.mxstep ) goto 100
+      iflag = 1
+
+ 500  continue
+
+      iwsp(1) = nmult
+      iwsp(2) = nexph
+      iwsp(3) = nscale
+      iwsp(4) = nstep
+      iwsp(5) = nreject
+      iwsp(6) = ibrkflag
+      iwsp(7) = mbrkdwn
+
+      wsp(1)  = step_min
+      wsp(2)  = step_max
+      wsp(3)  = 0.0d0
+      wsp(4)  = 0.0d0
+      wsp(5)  = x_error
+      wsp(6)  = s_error
+      wsp(7)  = tbrkdwn
+      wsp(8)  = sgn*t_now
+      wsp(9)  = hump/vnorm
+      wsp(10) = beta/vnorm
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine DSEXPV( n, m, t, v, w, tol, anorm,
+     .                   wsp,lwsp, iwsp,liwsp, matvec, itrace,iflag )
+
+      implicit none
+      integer n, m, lwsp, liwsp, itrace, iflag, iwsp(liwsp)
+      double precision t, tol, anorm, v(n), w(n), wsp(lwsp)
+      external matvec
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  DSEXPV computes w = exp(t*A)*v - for a Symmetric matrix A.
+*
+*     It does not compute the matrix exponential in isolation but
+*     instead, it computes directly the action of the exponential
+*     operator on the operand vector. This way of doing so allows 
+*     for addressing large sparse problems. 
+*
+*     The method used is based on Krylov subspace projection
+*     techniques and the matrix under consideration interacts only
+*     via the external routine `matvec' performing the matrix-vector 
+*     product (matrix-free method).
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     n      : (input) order of the principal matrix A.
+*                      
+*     m      : (input) maximum size for the Krylov basis.
+*                      
+*     t      : (input) time at wich the solution is needed (can be < 0).
+*                      
+*     v(n)   : (input) given operand vector.
+*
+*     w(n)   : (output) computed approximation of exp(t*A)*v.
+*
+*     tol    : (input/output) the requested accuracy tolerance on w. 
+*              If on input tol=0.0d0 or tol is too small (tol.le.eps)
+*              the internal value sqrt(eps) is used, and tol is set to
+*              sqrt(eps) on output (`eps' denotes the machine epsilon).
+*              (`Happy breakdown' is assumed if h(j+1,j) .le. anorm*tol)
+*
+*     anorm  : (input) an approximation of some norm of A.
+*
+*   wsp(lwsp): (workspace) lwsp .ge. n*(m+1)+n+(m+2)^2+4*(m+2)^2+ideg+1
+*                                   +---------+-------+---------------+
+*              (actually, ideg=6)        V        H      wsp for PADE
+*                   
+* iwsp(liwsp): (workspace) liwsp .ge. m+2
+*
+*     matvec : external subroutine for matrix-vector multiplication.
+*              synopsis: matvec( x, y )
+*                        double precision x(*), y(*)
+*              computes: y(1:n) <- A*x(1:n)
+*                        where A is the principal matrix.
+*
+*     itrace : (input) running mode. 0=silent, 1=print step-by-step info
+*
+*     iflag  : (output) exit flag.
+*              <0 - bad input arguments 
+*               0 - no problem
+*               1 - maximum number of steps reached without convergence
+*               2 - requested tolerance was too high
+*
+*-----Accounts on the computation--------------------------------------|
+*     Upon exit, an interested user may retrieve accounts on the 
+*     computations. They are located in the workspace arrays wsp and 
+*     iwsp as indicated below: 
+*
+*     location  mnemonic                 description
+*     -----------------------------------------------------------------|
+*     iwsp(1) = nmult, number of matrix-vector multiplications used
+*     iwsp(2) = nexph, nbr of Tridiagonal matrix exponential evaluated
+*     iwsp(3) = nscale, number of repeated squaring involved in Pade
+*     iwsp(4) = nstep, nbr of integration steps used up to completion 
+*     iwsp(5) = nreject, number of rejected step-sizes
+*     iwsp(6) = ibrkflag, set to 1 if `happy breakdown' and 0 otherwise
+*     iwsp(7) = mbrkdwn, if `happy brkdown', basis-size when it occured
+*     -----------------------------------------------------------------|
+*     wsp(1)  = step_min, minimum step-size used during integration
+*     wsp(2)  = step_max, maximum step-size used during integration
+*     wsp(3)  = dummy
+*     wsp(4)  = dummy
+*     wsp(5)  = x_error, maximum among all local truncation errors
+*     wsp(6)  = s_error, global sum of local truncation errors
+*     wsp(7)  = tbrkdwn, if `happy breakdown', time when it occured
+*     wsp(8)  = t_now, integration domain successfully covered
+*     wsp(9)  = hump, i.e., max||exp(sA)||, s in [0,t] (or [t,0] if t<0)
+*     wsp(10) = ||w||/||v||, scaled norm of the solution w.
+*     -----------------------------------------------------------------|
+*     The `hump' is a measure of the conditioning of the problem. The
+*     matrix exponential is well-conditioned if hump = 1, whereas it is
+*     poorly-conditioned if hump >> 1. However the solution can still be
+*     relatively fairly accurate even when the hump is large (the hump 
+*     is an upper bound), especially when the hump and the scaled norm
+*     of w [this is also computed and returned in wsp(10)] are of the 
+*     same order of magnitude (further details in reference below).
+*
+*----------------------------------------------------------------------|
+*-----The following parameters may also be adjusted herein-------------|
+*
+      integer mxstep, mxreject, ideg
+      double precision delta, gamma
+      parameter( mxstep   = 500,
+     .           mxreject = 0,
+     .           ideg     = 6,
+     .           delta    = 1.2d0,
+     .           gamma    = 0.9d0 )
+
+*     mxstep  : maximum allowable number of integration steps.
+*               The value 0 means an infinite number of steps.
+* 
+*     mxreject: maximum allowable number of rejections at each step. 
+*               The value 0 means an infinite number of rejections.
+*
+*     ideg    : the Pade approximation of type (ideg,ideg) is used as 
+*               an approximation to exp(H). The value 0 switches to the
+*               uniform rational Chebyshev approximation of type (14,14)
+*
+*     delta   : local truncation error `safety factor'
+*
+*     gamma   : stepsize `shrinking factor'
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      integer i, j, k1, mh, mx, iv, ih, j1v, ns, ifree, lfree, iexph,
+     .        ireject,ibrkflag,mbrkdwn, nmult, nreject, nexph, nscale,
+     .        nstep
+      double precision sgn, t_out, tbrkdwn, step_min,step_max, err_loc,
+     .                 s_error, x_error, t_now, t_new, t_step, t_old,
+     .                 xm, beta, break_tol, p1, p2, p3, eps, rndoff,
+     .                 vnorm, avnorm, hj1j, hjj, hump, SQR1
+
+      intrinsic AINT,ABS,DBLE,LOG10,MAX,MIN,NINT,SIGN,SQRT
+      double precision DDOT, DNRM2
+
+*---  check restrictions on input parameters ...
+      iflag = 0
+      if ( lwsp.lt.n*(m+2)+5*(m+2)**2+ideg+1 ) iflag = -1
+      if ( liwsp.lt.m+2 ) iflag = -2
+      if ( m.ge.n .or. m.le.0 ) iflag = -3
+      if ( iflag.ne.0 ) stop 'bad sizes (in input of DSEXPV)'
+*
+*---  initialisations ...
+*
+      k1 = 2
+      mh = m + 2
+      iv = 1
+      ih = iv + n*(m+1) + n
+      ifree = ih + mh*mh
+      lfree = lwsp - ifree + 1
+
+      ibrkflag = 0
+      mbrkdwn  = m
+      nmult    = 0
+      nreject  = 0
+      nexph    = 0
+      nscale   = 0
+
+      t_out    = ABS( t )
+      tbrkdwn  = 0.0d0
+      step_min = t_out
+      step_max = 0.0d0
+      nstep    = 0
+      s_error  = 0.0d0
+      x_error  = 0.0d0
+      t_now    = 0.0d0
+      t_new    = 0.0d0
+
+      p1 = 4.0d0/3.0d0
+ 1    p2 = p1 - 1.0d0
+      p3 = p2 + p2 + p2
+      eps = ABS( p3-1.0d0 )
+      if ( eps.eq.0.0d0 ) go to 1
+      if ( tol.le.eps ) tol = SQRT( eps )
+      rndoff = eps*anorm
+
+      break_tol = 1.0d-7
+*>>>  break_tol = tol
+*>>>  break_tol = anorm*tol
+
+      sgn = SIGN( 1.0d0,t )
+      call DCOPY( n, v,1, w,1 )
+      beta = DNRM2( n, w,1 )
+      vnorm = beta
+      hump = beta 
+*
+*---  obtain the very first stepsize ...
+*
+      SQR1 = SQRT( 0.1d0 )
+      xm = 1.0d0/DBLE( m )
+      p1 = tol*(((m+1)/2.72D0)**(m+1))*SQRT(2.0D0*3.14D0*(m+1))
+      t_new = (1.0d0/anorm)*(p1/(4.0d0*beta*anorm))**xm
+      p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+      t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+*
+*---  step-by-step integration ...
+*
+ 100  if ( t_now.ge.t_out ) goto 500
+
+      nstep = nstep + 1
+      t_step = MIN( t_out-t_now, t_new )
+
+      p1 = 1.0d0/beta
+      do i = 1,n
+         wsp(iv + i-1) = p1*w(i)
+      enddo
+      do i = 1,mh*mh
+         wsp(ih+i-1) = 0.0d0
+      enddo
+*
+*---  Lanczos loop ...
+*
+      j1v = iv + n
+      do 200 j = 1,m
+         nmult = nmult + 1
+         call matvec( wsp(j1v-n), wsp(j1v) )
+         if ( j.gt.1 )
+     .     call DAXPY(n,-wsp(ih+(j-1)*mh+j-2),wsp(j1v-2*n),1,wsp(j1v),1)
+         hjj = DDOT( n, wsp(j1v-n),1, wsp(j1v),1 )
+         call DAXPY( n, -hjj, wsp(j1v-n),1, wsp(j1v),1 )
+         hj1j = DNRM2( n, wsp(j1v),1 )
+         wsp(ih+(j-1)*(mh+1)) = hjj
+*---     if `happy breakdown' go straightforward at the end ... 
+         if ( hj1j.le.break_tol ) then
+            print*,'happy breakdown: mbrkdwn =',j,' h =',hj1j
+            k1 = 0
+            ibrkflag = 1
+            mbrkdwn = j
+            tbrkdwn = t_now
+            t_step = t_out-t_now
+            goto 300
+         endif
+         wsp(ih+(j-1)*mh+j) = hj1j
+         wsp(ih+j*mh+j-1) = hj1j
+         call DSCAL( n, 1.0d0/hj1j, wsp(j1v),1 )
+         j1v = j1v + n
+ 200  continue
+      nmult = nmult + 1
+      call matvec( wsp(j1v-n), wsp(j1v) )
+      avnorm = DNRM2( n, wsp(j1v),1 )
+*
+*---  set 1 for the 2-corrected scheme ...
+*
+ 300  continue
+      wsp(ih+m*mh+m-1) = 0.0d0
+      wsp(ih+m*mh+m+1) = 1.0d0
+*
+*---  loop while ireject<mxreject until the tolerance is reached ...
+*
+      ireject = 0
+ 401  continue
+*
+*---  compute w = beta*V*exp(t_step*H)*e1 ...
+*
+      nexph = nexph + 1
+      mx = mbrkdwn + k1
+      if ( ideg.ne.0 ) then
+*---     irreducible rational Pade approximation ...
+         call DGPADM( ideg, mx, sgn*t_step, wsp(ih),mh,
+     .                wsp(ifree),lfree, iwsp, iexph, ns, iflag )
+         iexph = ifree + iexph - 1
+         nscale = nscale + ns
+      else
+*---     uniform rational Chebyshev approximation ...
+         iexph = ifree
+         do i = 1,mx
+            wsp(iexph+i-1) = 0.0d0
+         enddo
+         wsp(iexph) = 1.0d0
+         call DNCHBV(mx,sgn*t_step,wsp(ih),mh,wsp(iexph),wsp(ifree+mx))
+      endif
+ 402  continue
+* 
+*---  error estimate ...
+*
+      if ( k1.eq.0 ) then
+         err_loc = tol
+      else
+         p1 = ABS( wsp(iexph+m) )   * beta
+         p2 = ABS( wsp(iexph+m+1) ) * beta * avnorm
+         if ( p1.gt.10.0d0*p2 ) then
+            err_loc = p2
+            xm = 1.0d0/DBLE( m )
+         elseif ( p1.gt.p2 ) then
+            err_loc = (p1*p2)/(p1-p2)
+            xm = 1.0d0/DBLE( m )
+         else
+            err_loc = p1
+            xm = 1.0d0/DBLE( m-1 )
+         endif
+      endif
+*
+*---  reject the step-size if the error is not acceptable ...
+*   
+      if ( (k1.ne.0) .and. (err_loc.gt.delta*t_step*tol) .and.
+     .     (mxreject.eq.0 .or. ireject.lt.mxreject) ) then
+         t_old = t_step
+         t_step = gamma * t_step * (t_step*tol/err_loc)**xm
+         p1 = 10.0d0**(NINT( LOG10( t_step )-SQR1 )-1)
+         t_step = AINT( t_step/p1 + 0.55d0 ) * p1
+         if ( itrace.ne.0 ) then
+            print*,'t_step =',t_old
+            print*,'err_loc =',err_loc
+            print*,'err_required =',delta*t_old*tol
+            print*,'stepsize rejected, stepping down to:',t_step
+         endif
+         ireject = ireject + 1
+         nreject = nreject + 1
+         if ( mxreject.ne.0 .and. ireject.gt.mxreject ) then
+            print*,"Failure in DSEXPV: ---"
+            print*,"The requested tolerance is too high."
+            Print*,"Rerun with a smaller value."
+            iflag = 2
+            return
+         endif
+         goto 401
+      endif
+*
+*---  now update w = beta*V*exp(t_step*H)*e1 and the hump ...
+*
+      mx = mbrkdwn + MAX( 0,k1-1 )
+      call DGEMV( 'n', n,mx,beta,wsp(iv),n,wsp(iexph),1,0.0d0,w,1 )
+      beta = DNRM2( n, w,1 )
+      hump = MAX( hump, beta )
+*
+*---  suggested value for the next stepsize ...
+*
+      t_new = gamma * t_step * (t_step*tol/err_loc)**xm
+      p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+      t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+
+      err_loc = MAX( err_loc,rndoff )
+*
+*---  update the time covered ...
+*
+      t_now = t_now + t_step
+*
+*---  display and keep some information ...
+*
+      if ( itrace.ne.0 ) then
+         print*,'integration',nstep,'---------------------------------'
+         print*,'scale-square =',ns
+         print*,'step_size =',t_step
+         print*,'err_loc   =',err_loc
+         print*,'next_step =',t_new
+      endif
+
+      step_min = MIN( step_min, t_step )
+      step_max = MAX( step_max, t_step )
+      s_error = s_error + err_loc
+      x_error = MAX( x_error, err_loc )
+
+      if ( mxstep.eq.0 .or. nstep.lt.mxstep ) goto 100
+      iflag = 1
+
+ 500  continue
+
+      iwsp(1) = nmult
+      iwsp(2) = nexph
+      iwsp(3) = nscale
+      iwsp(4) = nstep
+      iwsp(5) = nreject
+      iwsp(6) = ibrkflag
+      iwsp(7) = mbrkdwn
+
+      wsp(1)  = step_min
+      wsp(2)  = step_max
+      wsp(3)  = 0.0d0
+      wsp(4)  = 0.0d0
+      wsp(5)  = x_error
+      wsp(6)  = s_error
+      wsp(7)  = tbrkdwn
+      wsp(8)  = sgn*t_now
+      wsp(9)  = hump/vnorm
+      wsp(10) = beta/vnorm
+      END
+*----------------------------------------------------------------------|
+
+*----------------------------------------------------------------------|
+      subroutine ZGEXPV( n, m, t, v, w, tol, anorm,
+     .                   wsp,lwsp, iwsp,liwsp, matvec, itrace,iflag )
+
+      implicit none
+      integer          n, m, lwsp, liwsp, itrace, iflag, iwsp(liwsp)
+      double precision t, tol, anorm
+      complex*16       v(n), w(n), wsp(lwsp)
+      external         matvec
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  ZGEXPV computes w = exp(t*A)*v
+*     for a Zomplex (i.e., complex double precision) matrix A 
+*
+*     It does not compute the matrix exponential in isolation but
+*     instead, it computes directly the action of the exponential
+*     operator on the operand vector. This way of doing so allows 
+*     for addressing large sparse problems. 
+*
+*     The method used is based on Krylov subspace projection
+*     techniques and the matrix under consideration interacts only
+*     via the external routine `matvec' performing the matrix-vector 
+*     product (matrix-free method).
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     n      : (input) order of the principal matrix A.
+*
+*     m      : (input) maximum size for the Krylov basis.
+*
+*     t      : (input) time at wich the solution is needed (can be < 0).
+*
+*     v(n)   : (input) given operand vector.
+*
+*     w(n)   : (output) computed approximation of exp(t*A)*v.
+*
+*     tol    : (input/output) the requested accuracy tolerance on w. 
+*              If on input tol=0.0d0 or tol is too small (tol.le.eps)
+*              the internal value sqrt(eps) is used, and tol is set to
+*              sqrt(eps) on output (`eps' denotes the machine epsilon).
+*              (`Happy breakdown' is assumed if h(j+1,j) .le. anorm*tol)
+*
+*     anorm  : (input) an approximation of some norm of A.
+*
+*   wsp(lwsp): (workspace) lwsp .ge. n*(m+1)+n+(m+2)^2+4*(m+2)^2+ideg+1
+*                                   +---------+-------+---------------+
+*              (actually, ideg=6)        V        H      wsp for PADE
+*                   
+* iwsp(liwsp): (workspace) liwsp .ge. m+2
+*
+*     matvec : external subroutine for matrix-vector multiplication.
+*              synopsis: matvec( x, y )
+*                        complex*16 x(*), y(*)
+*              computes: y(1:n) <- A*x(1:n)
+*                        where A is the principal matrix.
+*
+*     itrace : (input) running mode. 0=silent, 1=print step-by-step info
+*
+*     iflag  : (output) exit flag.
+*              <0 - bad input arguments 
+*               0 - no problem
+*               1 - maximum number of steps reached without convergence
+*               2 - requested tolerance was too high
+*
+*-----Accounts on the computation--------------------------------------|
+*     Upon exit, an interested user may retrieve accounts on the 
+*     computations. They are located in the workspace arrays wsp and 
+*     iwsp as indicated below: 
+*
+*     location  mnemonic                 description
+*     -----------------------------------------------------------------|
+*     iwsp(1) = nmult, number of matrix-vector multiplications used
+*     iwsp(2) = nexph, number of Hessenberg matrix exponential evaluated
+*     iwsp(3) = nscale, number of repeated squaring involved in Pade
+*     iwsp(4) = nstep, number of integration steps used up to completion 
+*     iwsp(5) = nreject, number of rejected step-sizes
+*     iwsp(6) = ibrkflag, set to 1 if `happy breakdown' and 0 otherwise
+*     iwsp(7) = mbrkdwn, if `happy brkdown', basis-size when it occured
+*     -----------------------------------------------------------------|
+*     wsp(1)  = step_min, minimum step-size used during integration
+*     wsp(2)  = step_max, maximum step-size used during integration
+*     wsp(3)  = x_round, maximum among all roundoff errors (lower bound) 
+*     wsp(4)  = s_round, sum of roundoff errors (lower bound)
+*     wsp(5)  = x_error, maximum among all local truncation errors
+*     wsp(6)  = s_error, global sum of local truncation errors
+*     wsp(7)  = tbrkdwn, if `happy breakdown', time when it occured
+*     wsp(8)  = t_now, integration domain successfully covered
+*     wsp(9)  = hump, i.e., max||exp(sA)||, s in [0,t] (or [t,0] if t<0)
+*     wsp(10) = ||w||/||v||, scaled norm of the solution w.
+*     -----------------------------------------------------------------|
+*     The `hump' is a measure of the conditioning of the problem. The
+*     matrix exponential is well-conditioned if hump = 1, whereas it is
+*     poorly-conditioned if hump >> 1. However the solution can still be
+*     relatively fairly accurate even when the hump is large (the hump 
+*     is an upper bound), especially when the hump and the scaled norm
+*     of w [this is also computed and returned in wsp(10)] are of the 
+*     same order of magnitude (further details in reference below).
+*
+*----------------------------------------------------------------------|
+*-----The following parameters may also be adjusted herein-------------|
+*
+      integer mxstep, mxreject, ideg
+      double precision delta, gamma
+      parameter( mxstep   = 500,
+     .           mxreject = 0,
+     .           ideg     = 6,
+     .           delta    = 1.2d0,
+     .           gamma    = 0.9d0 )
+
+*     mxstep  : maximum allowable number of integration steps.
+*               The value 0 means an infinite number of steps.
+* 
+*     mxreject: maximum allowable number of rejections at each step. 
+*               The value 0 means an infinite number of rejections.
+*
+*     ideg    : the Pade approximation of type (ideg,ideg) is used as 
+*               an approximation to exp(H). The value 0 switches to the
+*               uniform rational Chebyshev approximation of type (14,14)
+*
+*     delta   : local truncation error `safety factor'
+*
+*     gamma   : stepsize `shrinking factor'
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+
+      complex*16 ZERO, ONE
+      parameter( ZERO=(0.0d0,0.0d0), ONE=(1.0d0,0.0d0) )
+      integer i, j, k1, mh, mx, iv, ih, j1v, ns, ifree, lfree, iexph,
+     .        ireject,ibrkflag,mbrkdwn, nmult, nreject, nexph, nscale,
+     .        nstep
+      double precision sgn, t_out, tbrkdwn, step_min,step_max, err_loc,
+     .                 s_error, x_error, t_now, t_new, t_step, t_old,
+     .                 xm, beta, break_tol, p1, p2, p3, eps, rndoff,
+     .                 vnorm, avnorm, hj1j, hump, SQR1
+      complex*16 hij
+
+      intrinsic AINT,ABS,CMPLX,DBLE,INT,LOG10,MAX,MIN,NINT,SIGN,SQRT
+      complex*16 ZDOTC
+      double precision DZNRM2
+*
+*---  check restrictions on input parameters ...
+*
+      iflag = 0
+      if ( lwsp.lt.n*(m+2)+5*(m+2)**2+ideg+1 ) iflag = -1
+      if ( liwsp.lt.m+2 ) iflag = -2
+      if ( m.ge.n .or. m.le.0 ) iflag = -3
+      if ( iflag.ne.0 ) stop 'bad sizes (in input of ZGEXPV)'
+*
+*---  initialisations ...
+*
+      k1 = 2
+      mh = m + 2
+      iv = 1
+      ih = iv + n*(m+1) + n
+      ifree = ih + mh*mh
+      lfree = lwsp - ifree + 1
+
+      ibrkflag = 0
+      mbrkdwn  = m
+      nmult    = 0
+      nreject  = 0
+      nexph    = 0
+      nscale   = 0
+
+      t_out    = ABS( t )
+      tbrkdwn  = 0.0d0
+      step_min = t_out
+      step_max = 0.0d0
+      nstep    = 0
+      s_error  = 0.0d0
+      x_error  = 0.0d0
+      t_now    = 0.0d0
+      t_new    = 0.0d0
+
+      p1 = 4.0d0/3.0d0
+ 1    p2 = p1 - 1.0d0
+      p3 = p2 + p2 + p2
+      eps = ABS( p3-1.0d0 )
+      if ( eps.eq.0.0d0 ) go to 1
+      if ( tol.le.eps ) tol = SQRT( eps )
+      rndoff = eps*anorm
+
+      break_tol = 1.0d-7
+*>>>  break_tol = tol
+*>>>  break_tol = anorm*tol
+
+      sgn = SIGN( 1.0d0,t )
+      call ZCOPY( n, v,1, w,1 )
+      beta = DZNRM2( n, w,1 )
+      vnorm = beta
+      hump = beta 
+*
+*---  obtain the very first stepsize ...
+*
+      SQR1 = SQRT( 0.1d0 )
+      xm = 1.0d0/DBLE( m )
+      p2 = tol*(((m+1)/2.72D0)**(m+1))*SQRT(2.0D0*3.14D0*(m+1))
+      t_new = (1.0d0/anorm)*(p2/(4.0d0*beta*anorm))**xm
+      p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+      t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+*
+*---  step-by-step integration ...
+*
+ 100  if ( t_now.ge.t_out ) goto 500
+
+      nstep = nstep + 1
+      t_step = MIN( t_out-t_now, t_new )
+      p1 = 1.0d0/beta
+      do i = 1,n
+         wsp(iv + i-1) = p1*w(i)
+      enddo
+      do i = 1,mh*mh
+         wsp(ih+i-1) = ZERO
+      enddo
+*
+*---  Arnoldi loop ...
+*
+      j1v = iv + n
+      do 200 j = 1,m
+         nmult = nmult + 1
+         call matvec( wsp(j1v-n), wsp(j1v) )
+         do i = 1,j
+            hij = ZDOTC( n, wsp(iv+(i-1)*n),1, wsp(j1v),1 )
+            call ZAXPY( n, -hij, wsp(iv+(i-1)*n),1, wsp(j1v),1 )
+            wsp(ih+(j-1)*mh+i-1) = hij
+         enddo
+         hj1j = DZNRM2( n, wsp(j1v),1 )
+*---     if `happy breakdown' go straightforward at the end ... 
+         if ( hj1j.le.break_tol ) then
+            print*,'happy breakdown: mbrkdwn =',j,' h =',hj1j
+            k1 = 0
+            ibrkflag = 1
+            mbrkdwn = j
+            tbrkdwn = t_now
+            t_step = t_out-t_now
+            goto 300
+         endif
+         wsp(ih+(j-1)*mh+j) = CMPLX( hj1j )
+         call ZDSCAL( n, 1.0d0/hj1j, wsp(j1v),1 )
+         j1v = j1v + n
+ 200  continue
+      nmult = nmult + 1
+      call matvec( wsp(j1v-n), wsp(j1v) )
+      avnorm = DZNRM2( n, wsp(j1v),1 )
+*
+*---  set 1 for the 2-corrected scheme ...
+*
+ 300  continue
+      wsp(ih+m*mh+m+1) = ONE
+*
+*---  loop while ireject<mxreject until the tolerance is reached ...
+*
+      ireject = 0
+ 401  continue
+*
+*---  compute w = beta*V*exp(t_step*H)*e1 ...
+*
+      nexph = nexph + 1
+      mx = mbrkdwn + k1
+      if ( ideg.ne.0 ) then
+*---     irreducible rational Pade approximation ...
+         call ZGPADM( ideg, mx, sgn*t_step, wsp(ih),mh,
+     .                wsp(ifree),lfree, iwsp, iexph, ns, iflag )
+         iexph = ifree + iexph - 1
+         nscale = nscale + ns
+      else
+*---     uniform rational Chebyshev approximation ...
+         iexph = ifree
+         do i = 1,mx
+            wsp(iexph+i-1) = ZERO
+         enddo
+         wsp(iexph) = ONE
+         call ZNCHBV(mx,sgn*t_step,wsp(ih),mh,wsp(iexph),wsp(ifree+mx))
+      endif
+ 402  continue
+* 
+*---  error estimate ...
+* 
+      if ( k1.eq.0 ) then
+         err_loc = tol
+      else
+         p1 = ABS( wsp(iexph+m) )   * beta
+         p2 = ABS( wsp(iexph+m+1) ) * beta * avnorm
+         if ( p1.gt.10.0d0*p2 ) then
+            err_loc = p2
+            xm = 1.0d0/DBLE( m )
+         elseif ( p1.gt.p2 ) then
+            err_loc = (p1*p2)/(p1-p2)
+            xm = 1.0d0/DBLE( m )
+         else
+            err_loc = p1
+            xm = 1.0d0/DBLE( m-1 )
+         endif
+      endif
+*
+*---  reject the step-size if the error is not acceptable ...
+*   
+      if ( (k1.ne.0) .and. (err_loc.gt.delta*t_step*tol) .and.
+     .     (mxreject.eq.0 .or. ireject.lt.mxreject) ) then
+         t_old = t_step
+         t_step = gamma * t_step * (t_step*tol/err_loc)**xm
+         p1 = 10.0d0**(NINT( LOG10( t_step )-SQR1 )-1)
+         t_step = AINT( t_step/p1 + 0.55d0 ) * p1
+         if ( itrace.ne.0 ) then
+            print*,'t_step =',t_old
+            print*,'err_loc =',err_loc
+            print*,'err_required =',delta*t_old*tol
+            print*,'stepsize rejected, stepping down to:',t_step
+         endif
+         ireject = ireject + 1
+         nreject = nreject + 1
+         if ( mxreject.ne.0 .and. ireject.gt.mxreject ) then
+            print*,"Failure in ZGEXPV: ---"
+            print*,"The requested tolerance is too high."
+            Print*,"Rerun with a smaller value."
+            iflag = 2
+            return
+         endif
+         goto 401
+      endif
+*
+*---  now update w = beta*V*exp(t_step*H)*e1 and the hump ...
+*
+      mx = mbrkdwn + MAX( 0,k1-1 )
+      hij = CMPLX( beta )
+      call ZGEMV( 'n', n,mx,hij,wsp(iv),n,wsp(iexph),1,ZERO,w,1 )
+      beta = DZNRM2( n, w,1 )
+      hump = MAX( hump, beta )
+*
+*---  suggested value for the next stepsize ...
+*
+      t_new = gamma * t_step * (t_step*tol/err_loc)**xm
+      p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+      t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+
+      err_loc = MAX( err_loc,rndoff )
+*
+*---  update the time covered ...
+*
+      t_now = t_now + t_step
+*
+*---  display and keep some information ...
+*
+      if ( itrace.ne.0 ) then
+         print*,'integration',nstep,'---------------------------------'
+         print*,'scale-square =',ns
+         print*,'step_size =',t_step
+         print*,'err_loc   =',err_loc
+         print*,'next_step =',t_new
+      endif
+
+      step_min = MIN( step_min, t_step )
+      step_max = MAX( step_max, t_step )
+      s_error = s_error + err_loc
+      x_error = MAX( x_error, err_loc )
+
+      if ( mxstep.eq.0 .or. nstep.lt.mxstep ) goto 100
+      iflag = 1
+
+ 500  continue
+
+      iwsp(1) = nmult
+      iwsp(2) = nexph
+      iwsp(3) = nscale
+      iwsp(4) = nstep
+      iwsp(5) = nreject
+      iwsp(6) = ibrkflag
+      iwsp(7) = mbrkdwn
+
+      wsp(1)  = CMPLX( step_min )
+      wsp(2)  = CMPLX( step_max )
+      wsp(3)  = CMPLX( 0.0d0 )
+      wsp(4)  = CMPLX( 0.0d0 )
+      wsp(5)  = CMPLX( x_error )
+      wsp(6)  = CMPLX( s_error )
+      wsp(7)  = CMPLX( tbrkdwn )
+      wsp(8)  = CMPLX( sgn*t_now )
+      wsp(9)  = CMPLX( hump/vnorm )
+      wsp(10) = CMPLX( beta/vnorm )
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine ZHEXPV( n, m, t, v, w, tol, anorm,
+     .                   wsp,lwsp, iwsp,liwsp, matvec, itrace,iflag )
+
+      implicit none
+      integer          n, m, lwsp, liwsp, itrace, iflag, iwsp(liwsp)
+      double precision t, tol, anorm
+      complex*16       v(n), w(n), wsp(lwsp)
+      external         matvec
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  ZHEXPV computes w = exp(t*A)*v for a Hermitian matrix A.
+*
+*     It does not compute the matrix exponential in isolation but
+*     instead, it computes directly the action of the exponential
+*     operator on the operand vector. This way of doing so allows 
+*     for addressing large sparse problems. 
+*
+*     The method used is based on Krylov subspace projection
+*     techniques and the matrix under consideration interacts only
+*     via the external routine `matvec' performing the matrix-vector 
+*     product (matrix-free method).
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     n      : (input) order of the principal matrix A.
+*                      
+*     m      : (input) maximum size for the Krylov basis.
+*                      
+*     t      : (input) time at wich the solution is needed (can be < 0).
+*                      
+*     v(n)   : (input) given operand vector.
+*
+*     w(n)   : (output) computed approximation of exp(t*A)*v.
+*
+*     tol    : (input/output) the requested accuracy tolerance on w. 
+*              If on input tol=0.0d0 or tol is too small (tol.le.eps)
+*              the internal value sqrt(eps) is used, and tol is set to
+*              sqrt(eps) on output (`eps' denotes the machine epsilon).
+*              (`Happy breakdown' is assumed if h(j+1,j) .le. anorm*tol)
+*
+*     anorm  : (input) an approximation of some norm of A.
+*
+*   wsp(lwsp): (workspace) lwsp .ge. n*(m+1)+n+(m+2)^2+4*(m+2)^2+ideg+1
+*                                   +---------+-------+---------------+
+*              (actually, ideg=6)        V        H      wsp for PADE
+*                   
+* iwsp(liwsp): (workspace) liwsp .ge. m+2
+*
+*     matvec : external subroutine for matrix-vector multiplication.
+*              synopsis: matvec( x, y )
+*                        complex*16 x(*), y(*)
+*              computes: y(1:n) <- A*x(1:n)
+*                        where A is the principal matrix.
+*
+*     itrace : (input) running mode. 0=silent, 1=print step-by-step info
+*
+*     iflag  : (output) exit flag.
+*              <0 - bad input arguments 
+*               0 - no problem
+*               1 - maximum number of steps reached without convergence
+*               2 - requested tolerance was too high
+*
+*-----Accounts on the computation--------------------------------------|
+*     Upon exit, an interested user may retrieve accounts on the 
+*     computations. They are located in the workspace arrays wsp and 
+*     iwsp as indicated below: 
+*
+*     location  mnemonic                 description
+*     -----------------------------------------------------------------|
+*     iwsp(1) = nmult, number of matrix-vector multiplications used
+*     iwsp(2) = nexph, number of Hessenberg matrix exponential evaluated
+*     iwsp(3) = nscale, number of repeated squaring involved in Pade
+*     iwsp(4) = nstep, number of integration steps used up to completion 
+*     iwsp(5) = nreject, number of rejected step-sizes
+*     iwsp(6) = ibrkflag, set to 1 if `happy breakdown' and 0 otherwise
+*     iwsp(7) = mbrkdwn, if `happy brkdown', basis-size when it occured
+*     -----------------------------------------------------------------|
+*     wsp(1)  = step_min, minimum step-size used during integration
+*     wsp(2)  = step_max, maximum step-size used during integration
+*     wsp(3)  = dummy
+*     wsp(4)  = dummy
+*     wsp(5)  = x_error, maximum among all local truncation errors
+*     wsp(6)  = s_error, global sum of local truncation errors
+*     wsp(7)  = tbrkdwn, if `happy breakdown', time when it occured
+*     wsp(8)  = t_now, integration domain successfully covered
+*     wsp(9)  = hump, i.e., max||exp(sA)||, s in [0,t] (or [t,0] if t<0)
+*     wsp(10) = ||w||/||v||, scaled norm of the solution w.
+*     -----------------------------------------------------------------|
+*     The `hump' is a measure of the conditioning of the problem. The
+*     matrix exponential is well-conditioned if hump = 1, whereas it is
+*     poorly-conditioned if hump >> 1. However the solution can still be
+*     relatively fairly accurate even when the hump is large (the hump 
+*     is an upper bound), especially when the hump and the scaled norm
+*     of w [this is also computed and returned in wsp(10)] are of the 
+*     same order of magnitude (further details in reference below).
+*
+*----------------------------------------------------------------------|
+*-----The following parameters may also be adjusted herein-------------|
+*
+      integer mxstep, mxreject, ideg
+      double precision delta, gamma
+      parameter( mxstep   = 500,
+     .           mxreject = 0,
+     .           ideg     = 6,
+     .           delta    = 1.2d0,
+     .           gamma    = 0.9d0 )
+
+*     mxstep  : maximum allowable number of integration steps.
+*               The value 0 means an infinite number of steps.
+* 
+*     mxreject: maximum allowable number of rejections at each step. 
+*               The value 0 means an infinite number of rejections.
+*
+*     ideg    : the Pade approximation of type (ideg,ideg) is used as 
+*               an approximation to exp(H). The value 0 switches to the
+*               uniform rational Chebyshev approximation of type (14,14)
+*
+*     delta   : local truncation error `safety factor'
+*
+*     gamma   : stepsize `shrinking factor'
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      complex*16 ZERO, ONE
+      parameter( ZERO=(0.0d0,0.0d0), ONE=(1.0d0,0.0d0) )
+      integer i, j, k1, mh, mx, iv, ih, j1v, ns, ifree, lfree, iexph,
+     .        ireject,ibrkflag,mbrkdwn, nmult, nreject, nexph, nscale,
+     .        nstep
+      double precision sgn, t_out, tbrkdwn, step_min,step_max, err_loc,
+     .                 s_error, x_error, t_now, t_new, t_step, t_old,
+     .                 xm, beta, break_tol, p1, p2, p3, eps, rndoff,
+     .                 vnorm, avnorm, hj1j, hump, SQR1
+      complex*16 hjj
+
+      intrinsic AINT,ABS,CMPLX,DBLE,INT,LOG10,MAX,MIN,NINT,SIGN,SQRT
+      complex*16 ZDOTC
+      double precision DZNRM2
+*
+*---  check restrictions on input parameters ...
+*
+      iflag = 0
+      if ( lwsp.lt.n*(m+2)+5*(m+2)**2+ideg+1 ) iflag = -1
+      if ( liwsp.lt.m+2 ) iflag = -2
+      if ( m.ge.n .or. m.le.0 ) iflag = -3
+      if ( iflag.ne.0 ) stop 'bad sizes (in input of DHEXPV)'
+*
+*---  initialisations ...
+*
+      k1 = 2
+      mh = m + 2
+      iv = 1
+      ih = iv + n*(m+1) + n
+      ifree = ih + mh*mh
+      lfree = lwsp - ifree + 1
+
+      ibrkflag = 0
+      mbrkdwn  = m
+      nmult    = 0
+      nreject  = 0
+      nexph    = 0
+      nscale   = 0
+
+      t_out    = ABS( t )
+      tbrkdwn  = 0.0d0
+      step_min = t_out
+      step_max = 0.0d0
+      nstep    = 0
+      s_error  = 0.0d0
+      x_error  = 0.0d0
+      t_now    = 0.0d0
+      t_new    = 0.0d0
+
+      p1 = 4.0d0/3.0d0
+ 1    p2 = p1 - 1.0d0
+      p3 = p2 + p2 + p2
+      eps = ABS( p3-1.0d0 )
+      if ( eps.eq.0.0d0 ) go to 1
+      if ( tol.le.eps ) tol = SQRT( eps )
+      rndoff = eps*anorm
+
+      break_tol = 1.0d-7
+*>>>  break_tol = tol
+*>>>  break_tol = anorm*tol
+
+      sgn = SIGN( 1.0d0,t )
+      call ZCOPY( n, v,1, w,1 )
+      beta = DZNRM2( n, w,1 )
+      vnorm = beta
+      hump = beta 
+*
+*---  obtain the very first stepsize ...
+*
+      SQR1 = SQRT( 0.1d0 )
+      xm = 1.0d0/DBLE( m )
+      p2 = tol*(((m+1)/2.72D0)**(m+1))*SQRT(2.0D0*3.14D0*(m+1))
+      t_new = (1.0d0/anorm)*(p2/(4.0d0*beta*anorm))**xm
+      p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+      t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+*
+*---  step-by-step integration ...
+*
+ 100  if ( t_now.ge.t_out ) goto 500
+
+      nstep = nstep + 1
+      t_step = MIN( t_out-t_now, t_new )
+      beta = DZNRM2( n, w,1 )
+      p1 = 1.0d0/beta
+      do i = 1,n
+         wsp(iv + i-1) = p1*w(i)
+      enddo
+      do i = 1,mh*mh
+         wsp(ih+i-1) = ZERO
+      enddo
+*
+*---  Lanczos loop ...
+*
+      j1v = iv + n
+      do 200 j = 1,m
+         nmult = nmult + 1
+         call matvec( wsp(j1v-n), wsp(j1v) )
+         if ( j.gt.1 )
+     .     call ZAXPY(n,-wsp(ih+(j-1)*mh+j-2),wsp(j1v-2*n),1,wsp(j1v),1)
+         hjj = ZDOTC( n, wsp(j1v-n),1, wsp(j1v),1 )
+         call ZAXPY( n, -hjj, wsp(j1v-n),1, wsp(j1v),1 )
+         hj1j = DZNRM2( n, wsp(j1v),1 )
+         wsp(ih+(j-1)*(mh+1)) = hjj
+*---     if `happy breakdown' go straightforward at the end ...
+         if ( hj1j.le.break_tol ) then
+            print*,'happy breakdown: mbrkdwn =',j,' h =',hj1j
+            k1 = 0
+            ibrkflag = 1
+            mbrkdwn = j
+            tbrkdwn = t_now
+            t_step = t_out-t_now
+            goto 300
+         endif
+         wsp(ih+(j-1)*mh+j) = CMPLX( hj1j )
+         wsp(ih+j*mh+j-1) = CMPLX( hj1j )
+         call ZDSCAL( n, 1.0d0/hj1j, wsp(j1v),1 )
+         j1v = j1v + n
+ 200  continue
+      nmult = nmult + 1
+      call matvec( wsp(j1v-n), wsp(j1v) )
+      avnorm = DZNRM2( n, wsp(j1v),1 )
+*
+*---  set 1 for the 2-corrected scheme ...
+*
+ 300  continue
+      wsp(ih+m*mh+m-1) = ZERO
+      wsp(ih+m*mh+m+1) = ONE
+*
+*---  loop while ireject<mxreject until the tolerance is reached ...
+*
+      ireject = 0
+ 401  continue
+*
+*---  compute w = beta*V*exp(t_step*H)*e1 ...
+*
+      nexph = nexph + 1
+      mx = mbrkdwn + k1
+      if ( ideg.ne.0 ) then
+*---     irreducible rational Pade approximation ...
+         call ZGPADM( ideg, mx, sgn*t_step, wsp(ih),mh,
+     .                wsp(ifree),lfree, iwsp, iexph, ns, iflag )
+         iexph = ifree + iexph - 1
+         nscale = nscale + ns
+      else
+*---     uniform rational Chebyshev approximation ...
+         iexph = ifree
+         do i = 1,mx
+            wsp(iexph+i-1) = ZERO
+         enddo
+         wsp(iexph) = ONE
+         call ZNCHBV(mx,sgn*t_step,wsp(ih),mh,wsp(iexph),wsp(ifree+mx))
+      endif
+
+ 402  continue
+* 
+*---  error estimate ...
+* 
+      if ( k1.eq.0 ) then
+         err_loc = tol
+      else
+         p1 = ABS( wsp(iexph+m) )   * beta
+         p2 = ABS( wsp(iexph+m+1) ) * beta * avnorm
+         if ( p1.gt.10.0d0*p2 ) then
+            err_loc = p2
+            xm = 1.0d0/DBLE( m )
+         elseif ( p1.gt.p2 ) then
+            err_loc = (p1*p2)/(p1-p2)
+            xm = 1.0d0/DBLE( m )
+         else
+            err_loc = p1
+            xm = 1.0d0/DBLE( m-1 )
+         endif
+      endif
+*
+*---  reject the step-size if the error is not acceptable ...
+*   
+      if ( (k1.ne.0) .and. (err_loc.gt.delta*t_step*tol) .and.
+     .     (mxreject.eq.0 .or. ireject.lt.mxreject) ) then
+         t_old = t_step
+         t_step = gamma * t_step * (t_step*tol/err_loc)**xm
+         p1 = 10.0d0**(NINT( LOG10( t_step )-SQR1 )-1)
+         t_step = AINT( t_step/p1 + 0.55d0 ) * p1
+         if ( itrace.ne.0 ) then
+            print*,'t_step =',t_old
+            print*,'err_loc =',err_loc
+            print*,'err_required =',delta*t_old*tol
+            print*,'stepsize rejected, stepping down to:',t_step
+         endif
+         ireject = ireject + 1
+         nreject = nreject + 1
+         if ( mxreject.ne.0 .and. ireject.gt.mxreject ) then
+            print*,"Failure in ZHEXPV: ---"
+            print*,"The requested tolerance is too high."
+            Print*,"Rerun with a smaller value."
+            iflag = 2
+            return
+         endif
+         goto 401
+      endif
+*
+*---  now update w = beta*V*exp(t_step*H)*e1 and the hump ...
+*
+      mx = mbrkdwn + MAX( 0,k1-1 )
+      hjj = CMPLX( beta )
+      call ZGEMV( 'n', n,mx,hjj,wsp(iv),n,wsp(iexph),1,ZERO,w,1 )
+      beta = DZNRM2( n, w,1 )
+      hump = MAX( hump, beta )
+*
+*---  suggested value for the next stepsize ...
+*
+      t_new = gamma * t_step * (t_step*tol/err_loc)**xm
+      p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+      t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+
+      err_loc = MAX( err_loc,rndoff )
+*
+*---  update the time covered ...
+*
+      t_now = t_now + t_step
+*
+*---  display and keep some information ...
+*
+      if ( itrace.ne.0 ) then
+         print*,'integration',nstep,'---------------------------------'
+         print*,'scale-square =',ns
+         print*,'step_size =',t_step
+         print*,'err_loc   =',err_loc
+         print*,'next_step =',t_new
+      endif
+
+      step_min = MIN( step_min, t_step )
+      step_max = MAX( step_max, t_step )
+      s_error = s_error + err_loc
+      x_error = MAX( x_error, err_loc )
+
+      if ( mxstep.eq.0 .or. nstep.lt.mxstep ) goto 100
+      iflag = 1
+
+ 500  continue
+
+      iwsp(1) = nmult
+      iwsp(2) = nexph
+      iwsp(3) = nscale
+      iwsp(4) = nstep
+      iwsp(5) = nreject
+      iwsp(6) = ibrkflag
+      iwsp(7) = mbrkdwn
+
+      wsp(1)  = CMPLX( step_min )
+      wsp(2)  = CMPLX( step_max )
+      wsp(3)  = CMPLX( 0.0d0 )
+      wsp(4)  = CMPLX( 0.0d0 )
+      wsp(5)  = CMPLX( x_error )
+      wsp(6)  = CMPLX( s_error )
+      wsp(7)  = CMPLX( tbrkdwn )
+      wsp(8)  = CMPLX( sgn*t_now )
+      wsp(9)  = CMPLX( hump/vnorm )
+      wsp(10) = CMPLX( beta/vnorm )
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine DGPHIV( n, m, t, u, v, w, tol, anorm,
+     .                   wsp,lwsp, iwsp,liwsp, matvec, itrace,iflag ) 
+
+      implicit none
+      integer n, m, lwsp, liwsp, itrace, iflag, iwsp(liwsp)
+      double precision t, tol, anorm, u(n), v(n), w(n), wsp(lwsp)
+      external matvec
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  DGPHIV computes w = exp(t*A)v + t*phi(tA)u which is the solution 
+*     of the nonhomogeneous linear ODE problem w' = Aw + u, w(0) = v.
+*     phi(z) = (exp(z)-1)/z and A is a General matrix.
+*
+*     The method used is based on Krylov subspace projection
+*     techniques and the matrix under consideration interacts only
+*     via the external routine `matvec' performing the matrix-vector 
+*     product (matrix-free method).
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     n      : (input) order of the principal matrix A.
+*                      
+*     m      : (input) maximum size for the Krylov basis.
+*                      
+*     t      : (input) time at wich the solution is needed (can be < 0).
+*   
+*     u(n)   : (input) operand vector with respect to the phi function
+*              (forcing term of the ODE problem).
+*
+*     v(n)   : (input) operand vector with respect to the exp function
+*              (initial condition of the ODE problem).
+*  
+*     w(n)   : (output) computed approximation of exp(t*A)v + t*phi(tA)u 
+* 
+*     tol    : (input/output) the requested accuracy tolerance on w. 
+*              If on input tol=0.0d0 or tol is too small (tol.le.eps)
+*              the internal value sqrt(eps) is used, and tol is set to
+*              sqrt(eps) on output (`eps' denotes the machine epsilon).
+*              (`Happy breakdown' is assumed if h(j+1,j) .le. anorm*tol)
+*
+*     anorm  : (input) an approximation of some norm of A.
+*
+*   wsp(lwsp): (workspace) lwsp .ge. n*(m+1)+n+(m+3)^2+4*(m+3)^2+ideg+1
+*                                   +---------+-------+---------------+
+*              (actually, ideg=6)        V        H      wsp for PADE
+*                   
+* iwsp(liwsp): (workspace) liwsp .ge. m+3
+*
+*     matvec : external subroutine for matrix-vector multiplication.
+*              synopsis: matvec( x, y )
+*                        double precision x(*), y(*)
+*              computes: y(1:n) <- A*x(1:n)
+*                        where A is the principal matrix.
+*
+*     itrace : (input) running mode. 0=silent, 1=print step-by-step info
+*
+*     iflag  : (output) exit flag.
+*              <0 - bad input arguments 
+*               0 - no problem
+*               1 - maximum number of steps reached without convergence
+*               2 - requested tolerance was too high
+*
+*-----Accounts on the computation--------------------------------------|
+*     Upon exit, an interested user may retrieve accounts on the 
+*     computations. They are located in the workspace arrays wsp and 
+*     iwsp as indicated below: 
+*
+*     location  mnemonic                 description
+*     -----------------------------------------------------------------|
+*     iwsp(1) = nmult, number of matrix-vector multiplications used
+*     iwsp(2) = nexph, number of Hessenberg matrix exponential evaluated
+*     iwsp(3) = nscale, number of repeated squaring involved in Pade
+*     iwsp(4) = nstep, number of integration steps used up to completion 
+*     iwsp(5) = nreject, number of rejected step-sizes
+*     iwsp(6) = ibrkflag, set to 1 if `happy breakdown' and 0 otherwise
+*     iwsp(7) = mbrkdwn, if `happy brkdown', basis-size when it occured
+*     -----------------------------------------------------------------|
+*     wsp(1)  = step_min, minimum step-size used during integration
+*     wsp(2)  = step_max, maximum step-size used during integration
+*     wsp(3)  = dummy
+*     wsp(4)  = dummy
+*     wsp(5)  = x_error, maximum among all local truncation errors
+*     wsp(6)  = s_error, global sum of local truncation errors
+*     wsp(7)  = tbrkdwn, if `happy breakdown', time when it occured
+*     wsp(8)  = t_now, integration domain successfully covered
+*
+*----------------------------------------------------------------------|
+*-----The following parameters may also be adjusted herein-------------|
+*
+      integer mxstep, mxreject, ideg
+      double precision delta, gamma
+      parameter( mxstep   = 1000, 
+     .           mxreject = 0,
+     .           ideg     = 6, 
+     .           delta    = 1.2d0,
+     .           gamma    = 0.9d0 )
+
+*     mxstep  : maximum allowable number of integration steps.
+*               The value 0 means an infinite number of steps.
+* 
+*     mxreject: maximum allowable number of rejections at each step. 
+*               The value 0 means an infinite number of rejections.
+*
+*     ideg    : the Pade approximation of type (ideg,ideg) is used as 
+*               an approximation to exp(H).
+*
+*     delta   : local truncation error `safety factor'
+*
+*     gamma   : stepsize `shrinking factor'
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      integer i, j, k1, mh, mx, iv, ih, j1v, ns, ifree, lfree, iexph,
+     .        ireject,ibrkflag,mbrkdwn, nmult, nreject, nexph, nscale,
+     .        nstep, iphih
+      double precision sgn, t_out, tbrkdwn, step_min,step_max, err_loc,
+     .                 s_error, x_error, t_now, t_new, t_step, t_old,
+     .                 xm, beta, break_tol, p1, p2, p3, eps, rndoff,
+     .                 avnorm, hj1j, hij, SQR1
+
+      intrinsic AINT,ABS,DBLE,LOG10,MAX,MIN,NINT,SIGN,SQRT
+      double precision DDOT, DNRM2
+
+*---  check restrictions on input parameters ...
+      iflag = 0
+      if ( lwsp.lt.n*(m+3)+5*(m+3)**2+ideg+1 ) iflag = -1
+      if ( liwsp.lt.m+3 ) iflag = -2
+      if ( m.ge.n .or. m.le.0 ) iflag = -3
+      if ( iflag.ne.0 ) stop 'bad sizes (in input of DGPHIV)'
+*
+*---  initialisations ...
+*
+      k1 = 3
+      mh = m + 3
+      iv = 1 
+      ih = iv + n*(m+1) + n
+      ifree = ih + mh*mh
+      lfree = lwsp - ifree + 1
+
+      ibrkflag = 0
+      mbrkdwn  = m
+      nmult    = 0
+      nreject  = 0
+      nexph    = 0
+      nscale   = 0
+
+      t_out    = ABS( t )
+      tbrkdwn  = 0.0d0
+      step_min = t_out
+      step_max = 0.0d0
+      nstep    = 0
+      s_error  = 0.0d0
+      x_error  = 0.0d0
+      t_now    = 0.0d0
+      t_new    = 0.0d0
+
+      p1 = 4.0d0/3.0d0
+ 1    p2 = p1 - 1.0d0
+      p3 = p2 + p2 + p2
+      eps = ABS( p3-1.0d0 )
+      if ( eps.eq.0.0d0 ) go to 1
+      if ( tol.le.eps ) tol = SQRT( eps )
+      rndoff = eps*anorm
+ 
+      break_tol = 1.0d-7
+*>>>  break_tol = tol
+*>>>  break_tol = anorm*tol
+
+*
+*---  step-by-step integration ...
+*
+      sgn = SIGN( 1.0d0,t )
+      SQR1 = SQRT( 0.1d0 )
+      call DCOPY( n, v,1, w,1 )
+
+ 100  if ( t_now.ge.t_out ) goto 500
+
+      nmult =  nmult + 1
+      call matvec( w, wsp(iv) )
+      call DAXPY( n, 1.0d0, u,1, wsp(iv),1 )
+      beta = DNRM2( n, wsp(iv),1 )
+      if ( beta.eq.0.0d0 ) goto 500
+      call DSCAL( n, 1.0d0/beta, wsp(iv),1 )
+      do i = 1,mh*mh
+         wsp(ih+i-1) = 0.0d0
+      enddo
+
+      if ( nstep.eq.0 ) then
+*---     obtain the very first stepsize ...
+         xm = 1.0d0/DBLE( m )
+         p1 = tol*(((m+1)/2.72D0)**(m+1))*SQRT(2.0D0*3.14D0*(m+1))
+         t_new = (1.0d0/anorm)*(p1/(4.0d0*beta*anorm))**xm
+         p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+         t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+      endif
+      nstep = nstep + 1
+      t_step = MIN( t_out-t_now, t_new )
+*
+*---  Arnoldi loop ...
+*
+      j1v = iv + n
+      do 200 j = 1,m
+         nmult = nmult + 1
+         call matvec( wsp(j1v-n), wsp(j1v) )
+         do i = 1,j
+            hij = DDOT( n, wsp(iv+(i-1)*n),1, wsp(j1v),1 )
+            call DAXPY( n, -hij, wsp(iv+(i-1)*n),1, wsp(j1v),1 )
+            wsp(ih+(j-1)*mh+i-1) = hij
+         enddo
+         hj1j = DNRM2( n, wsp(j1v),1 )
+*---     if `happy breakdown' go straightforward at the end ... 
+         if ( hj1j.le.break_tol ) then
+            print*,'happy breakdown: mbrkdwn =',j,' h =',hj1j
+            k1 = 0
+            ibrkflag = 1
+            mbrkdwn = j
+            tbrkdwn = t_now
+            t_step = t_out-t_now
+            goto 300
+         endif
+         wsp(ih+(j-1)*mh+j) = hj1j
+         call DSCAL( n, 1.0d0/hj1j, wsp(j1v),1 )
+         j1v = j1v + n
+ 200  continue
+      nmult = nmult + 1
+      call matvec( wsp(j1v-n), wsp(j1v) )
+      avnorm = DNRM2( n, wsp(j1v),1 )
+*
+*---  set 1's for the 3-extended scheme ...
+*
+ 300  continue
+      wsp(ih+mh*mbrkdwn) = 1.0d0
+      wsp(ih+(m-1)*mh+m) = 0.0d0
+      do i = 1,k1-1
+         wsp(ih+(m+i)*mh+m+i-1) = 1.0d0
+      enddo
+*
+*---  loop while ireject<mxreject until the tolerance is reached ...
+*
+      ireject = 0
+ 401  continue
+*
+*---  compute w = beta*t_step*V*phi(t_step*H)*e1 + w
+*
+      nexph = nexph + 1
+*---  irreducible rational Pade approximation ...
+      mx = mbrkdwn + MAX( 1,k1 )
+      call DGPADM( ideg, mx, sgn*t_step, wsp(ih),mh,
+     .             wsp(ifree),lfree, iwsp, iexph, ns, iflag )
+      iexph = ifree + iexph - 1
+      iphih = iexph + mbrkdwn*mx
+      nscale = nscale + ns
+      wsp(iphih+mbrkdwn)   = hj1j*wsp(iphih+mx+mbrkdwn-1)
+      wsp(iphih+mbrkdwn+1) = hj1j*wsp(iphih+2*mx+mbrkdwn-1)
+ 
+ 402  continue
+*---  error estimate ...
+      if ( k1.eq.0 ) then
+         err_loc = tol
+      else
+         p1 = ABS( wsp(iphih+m) )   * beta
+         p2 = ABS( wsp(iphih+m+1) ) * beta * avnorm 
+         if ( p1.gt.10.0d0*p2 ) then
+            err_loc = p2
+            xm = 1.0d0/DBLE( m+1 )
+         elseif ( p1.gt.p2 ) then
+            err_loc = (p1*p2)/(p1-p2)
+            xm = 1.0d0/DBLE( m+1 )
+         else
+            err_loc = p1
+            xm = 1.0d0/DBLE( m )
+         endif
+      endif
+
+*---  reject the step-size if the error is not acceptable ...   
+      if ( (k1.ne.0) .and. (err_loc.gt.delta*t_step*tol) .and. 
+     .     (mxreject.eq.0 .or. ireject.lt.mxreject) ) then
+         t_old = t_step
+         t_step = gamma * t_step * (t_step*tol/err_loc)**xm
+         p1 = 10.0d0**(NINT( LOG10( t_step )-SQR1 )-1)
+         t_step = AINT( t_step/p1 + 0.55d0 ) * p1
+         if ( itrace.ne.0 ) then
+            print*,'t_step =',t_old
+            print*,'err_loc =',err_loc
+            print*,'err_required =',delta*t_old*tol
+            print*,'stepsize rejected, stepping down to:',t_step
+         endif 
+         ireject = ireject + 1
+         nreject = nreject + 1
+         if ( mxreject.ne.0 .and. ireject.gt.mxreject ) then
+            print*,"Failure in DGPHIV: ---"
+            print*,"The requested tolerance is too high."
+            Print*,"Rerun with a smaller value."
+            iflag = 2
+            return
+         endif
+         goto 401
+      endif
+*
+      mx = mbrkdwn + MAX( 0,k1-2 )
+      call DGEMV( 'n', n,mx,beta,wsp(iv),n,wsp(iphih),1,1.0d0,w,1 )
+*
+*---  suggested value for the next stepsize ...
+*
+      t_new = gamma * t_step * (t_step*tol/err_loc)**xm
+      p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+      t_new = AINT( t_new/p1 + 0.55d0 ) * p1 
+
+      err_loc = MAX( err_loc,rndoff )
+*
+*---  update the time covered ...
+*
+      t_now = t_now + t_step 
+*
+*---  display and keep some information ...
+*
+      if ( itrace.ne.0 ) then
+         print*,'integration',nstep,'---------------------------------'
+         print*,'scale-square =',ns
+         print*,'step_size =',t_step
+         print*,'err_loc   =',err_loc
+         print*,'next_step =',t_new
+      endif
+ 
+      step_min = MIN( step_min, t_step ) 
+      step_max = MAX( step_max, t_step )
+      s_error = s_error + err_loc
+      x_error = MAX( x_error, err_loc )
+ 
+      if ( mxstep.eq.0 .or. nstep.lt.mxstep ) goto 100
+      iflag = 1
+ 
+ 500  continue
+
+      iwsp(1) = nmult
+      iwsp(2) = nexph
+      iwsp(3) = nscale
+      iwsp(4) = nstep
+      iwsp(5) = nreject
+      iwsp(6) = ibrkflag
+      iwsp(7) = mbrkdwn
+
+      wsp(1)  = step_min
+      wsp(2)  = step_max
+      wsp(3)  = 0.0d0
+      wsp(4)  = 0.0d0
+      wsp(5)  = x_error
+      wsp(6)  = s_error
+      wsp(7)  = tbrkdwn
+      wsp(8)  = sgn*t_now
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine DSPHIV( n, m, t, u, v, w, tol, anorm,
+     .                   wsp,lwsp, iwsp,liwsp, matvec, itrace,iflag ) 
+
+      implicit none
+      integer n, m, lwsp, liwsp, itrace, iflag, iwsp(liwsp)
+      double precision t, tol, anorm, u(n), v(n), w(n), wsp(lwsp)
+      external matvec
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  DSPHIV computes w = exp(t*A)v + t*phi(tA)u which is the solution 
+*     of the nonhomogeneous linear ODE problem w' = Aw + u, w(0) = v.
+*     phi(z) = (exp(z)-1)/z and A is a Symmetric matrix.
+*
+*     The method used is based on Krylov subspace projection
+*     techniques and the matrix under consideration interacts only
+*     via the external routine `matvec' performing the matrix-vector 
+*     product (matrix-free method).
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     n      : (input) order of the principal matrix A.
+*                      
+*     m      : (input) maximum size for the Krylov basis.
+*                      
+*     t      : (input) time at wich the solution is needed (can be < 0).
+*   
+*     u(n)   : (input) operand vector with respect to the phi function
+*              (forcing term of the ODE problem).
+*
+*     v(n)   : (input) operand vector with respect to the exp function
+*              (initial condition of the ODE problem).
+*  
+*     w(n)   : (output) computed approximation of exp(t*A)v + t*phi(tA)u 
+* 
+*     tol    : (input/output) the requested accuracy tolerance on w. 
+*              If on input tol=0.0d0 or tol is too small (tol.le.eps)
+*              the internal value sqrt(eps) is used, and tol is set to
+*              sqrt(eps) on output (`eps' denotes the machine epsilon).
+*              (`Happy breakdown' is assumed if h(j+1,j) .le. anorm*tol)
+*
+*     anorm  : (input) an approximation of some norm of A.
+*
+*   wsp(lwsp): (workspace) lwsp .ge. n*(m+1)+n+(m+3)^2+4*(m+3)^2+ideg+1
+*                                   +---------+-------+---------------+
+*              (actually, ideg=6)        V        H      wsp for PADE
+*                   
+* iwsp(liwsp): (workspace) liwsp .ge. m+3
+*
+*     matvec : external subroutine for matrix-vector multiplication.
+*              synopsis: matvec( x, y )
+*                        double precision x(*), y(*)
+*              computes: y(1:n) <- A*x(1:n)
+*                        where A is the principal matrix.
+*
+*     itrace : (input) running mode. 0=silent, 1=print step-by-step info
+*
+*     iflag  : (output) exit flag.
+*              <0 - bad input arguments 
+*               0 - no problem
+*               1 - maximum number of steps reached without convergence
+*               2 - requested tolerance was too high
+*
+*-----Accounts on the computation--------------------------------------|
+*     Upon exit, an interested user may retrieve accounts on the 
+*     computations. They are located in the workspace arrays wsp and 
+*     iwsp as indicated below: 
+*
+*     location  mnemonic                 description
+*     -----------------------------------------------------------------|
+*     iwsp(1) = nmult, number of matrix-vector multiplications used
+*     iwsp(2) = nexph, number of Hessenberg matrix exponential evaluated
+*     iwsp(3) = nscale, number of repeated squaring involved in Pade
+*     iwsp(4) = nstep, number of integration steps used up to completion 
+*     iwsp(5) = nreject, number of rejected step-sizes
+*     iwsp(6) = ibrkflag, set to 1 if `happy breakdown' and 0 otherwise
+*     iwsp(7) = mbrkdwn, if `happy brkdown', basis-size when it occured
+*     -----------------------------------------------------------------|
+*     wsp(1)  = step_min, minimum step-size used during integration
+*     wsp(2)  = step_max, maximum step-size used during integration
+*     wsp(3)  = dummy
+*     wsp(4)  = dummy
+*     wsp(5)  = x_error, maximum among all local truncation errors
+*     wsp(6)  = s_error, global sum of local truncation errors
+*     wsp(7)  = tbrkdwn, if `happy breakdown', time when it occured
+*     wsp(8)  = t_now, integration domain successfully covered
+*
+*----------------------------------------------------------------------|
+*-----The following parameters may also be adjusted herein-------------|
+*
+      integer mxstep, mxreject, ideg
+      double precision delta, gamma
+      parameter( mxstep   = 500, 
+     .           mxreject = 0,
+     .           ideg     = 6, 
+     .           delta    = 1.2d0,
+     .           gamma    = 0.9d0 )
+
+*     mxstep  : maximum allowable number of integration steps.
+*               The value 0 means an infinite number of steps.
+* 
+*     mxreject: maximum allowable number of rejections at each step. 
+*               The value 0 means an infinite number of rejections.
+*
+*     ideg    : the Pade approximation of type (ideg,ideg) is used as 
+*               an approximation to exp(H).
+*
+*     delta   : local truncation error `safety factor'
+*
+*     gamma   : stepsize `shrinking factor'
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      integer i, j, k1, mh, mx, iv, ih, j1v, ns, ifree, lfree, iexph,
+     .        ireject,ibrkflag,mbrkdwn, nmult, nreject, nexph, nscale,
+     .        nstep, iphih
+      double precision sgn, t_out, tbrkdwn, step_min,step_max, err_loc,
+     .                 s_error, x_error, t_now, t_new, t_step, t_old,
+     .                 xm, beta, break_tol, p1, p2, p3, eps, rndoff,
+     .                 avnorm, hj1j, hjj, SQR1
+
+      intrinsic AINT,ABS,DBLE,LOG10,MAX,MIN,NINT,SIGN,SQRT
+      double precision DDOT, DNRM2
+
+*---  check restrictions on input parameters ...
+      iflag = 0
+      if ( lwsp.lt.n*(m+3)+5*(m+3)**2+ideg+1 ) iflag = -1
+      if ( liwsp.lt.m+3 ) iflag = -2
+      if ( m.ge.n .or. m.le.0 ) iflag = -3
+      if ( iflag.ne.0 ) stop 'bad sizes (in input of DSPHIV)'
+*
+*---  initialisations ...
+*
+      k1 = 3
+      mh = m + 3
+      iv = 1 
+      ih = iv + n*(m+1) + n
+      ifree = ih + mh*mh
+      lfree = lwsp - ifree + 1
+
+      ibrkflag = 0
+      mbrkdwn  = m
+      nmult    = 0
+      nreject  = 0
+      nexph    = 0
+      nscale   = 0
+
+      t_out    = ABS( t )
+      tbrkdwn  = 0.0d0
+      step_min = t_out
+      step_max = 0.0d0
+      nstep    = 0
+      s_error  = 0.0d0
+      x_error  = 0.0d0
+      t_now    = 0.0d0
+      t_new    = 0.0d0
+
+      p1 = 4.0d0/3.0d0
+ 1    p2 = p1 - 1.0d0
+      p3 = p2 + p2 + p2
+      eps = ABS( p3-1.0d0 )
+      if ( eps.eq.0.0d0 ) go to 1
+      if ( tol.le.eps ) tol = SQRT( eps )
+      rndoff = eps*anorm
+ 
+      break_tol = 1.0d-7
+*>>>  break_tol = tol
+*>>>  break_tol = anorm*tol
+
+*
+*---  step-by-step integration ...
+*
+      sgn = SIGN( 1.0d0,t )
+      SQR1 = SQRT( 0.1d0 )
+      call DCOPY( n, v,1, w,1 )
+
+ 100  if ( t_now.ge.t_out ) goto 500
+
+      nmult =  nmult + 1
+      call matvec( w, wsp(iv) )
+      call DAXPY( n, 1.0d0, u,1, wsp(iv),1 )
+      beta = DNRM2( n, wsp(iv),1 )
+      if ( beta.eq.0.0d0 ) goto 500
+      call DSCAL( n, 1.0d0/beta, wsp(iv),1 )
+      do i = 1,mh*mh
+         wsp(ih+i-1) = 0.0d0
+      enddo
+
+      if ( nstep.eq.0 ) then
+*---     obtain the very first stepsize ...
+         xm = 1.0d0/DBLE( m )
+         p1 = tol*(((m+1)/2.72D0)**(m+1))*SQRT(2.0D0*3.14D0*(m+1))
+         t_new = (1.0d0/anorm)*(p1/(4.0d0*beta*anorm))**xm
+         p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+         t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+      endif
+      nstep = nstep + 1
+      t_step = MIN( t_out-t_now, t_new )
+*
+*---  Lanczos loop ...
+*
+      j1v = iv + n
+      do 200 j = 1,m
+         nmult = nmult + 1
+         call matvec( wsp(j1v-n), wsp(j1v) )
+         if ( j.gt.1 )
+     .     call DAXPY(n,-wsp(ih+(j-1)*mh+j-2),wsp(j1v-2*n),1,wsp(j1v),1)
+         hjj = DDOT( n, wsp(j1v-n),1, wsp(j1v),1 )
+         call DAXPY( n, -hjj, wsp(j1v-n),1, wsp(j1v),1 )
+         hj1j = DNRM2( n, wsp(j1v),1 )
+         wsp(ih+(j-1)*(mh+1)) = hjj
+*---     if `happy breakdown' go straightforward at the end ... 
+         if ( hj1j.le.break_tol ) then
+            print*,'happy breakdown: mbrkdwn =',j,' h =',hj1j
+            k1 = 0
+            ibrkflag = 1
+            mbrkdwn = j
+            tbrkdwn = t_now
+            t_step = t_out-t_now
+            goto 300
+         endif
+         wsp(ih+(j-1)*mh+j) = hj1j
+         wsp(ih+j*mh+j-1) = hj1j
+         call DSCAL( n, 1.0d0/hj1j, wsp(j1v),1 )
+         j1v = j1v + n
+ 200  continue
+      nmult = nmult + 1
+      call matvec( wsp(j1v-n), wsp(j1v) )
+      avnorm = DNRM2( n, wsp(j1v),1 )
+*
+*---  set 1's for the 3-extended scheme ...
+*
+ 300  continue
+      wsp(ih+mh*mbrkdwn) = 1.0d0
+      wsp(ih+m*mh+m-1)   = 0.0d0
+      wsp(ih+(m-1)*mh+m) = 0.0d0
+      do i = 1,k1-1
+         wsp(ih+(m+i)*mh+m+i-1) = 1.0d0
+      enddo
+*
+*---  loop while ireject<mxreject until the tolerance is reached ...
+*
+      ireject = 0
+ 401  continue
+*
+*---  compute w = beta*t_step*V*phi(t_step*H)*e1 + w
+*
+      nexph = nexph + 1
+      mx = mbrkdwn + MAX( 1,k1 )
+
+*---  irreducible rational Pade approximation ...
+      call DGPADM( ideg, mx, sgn*t_step, wsp(ih),mh,
+     .              wsp(ifree),lfree, iwsp, iexph, ns, iflag )
+      iexph = ifree + iexph - 1
+      iphih = iexph + mbrkdwn*mx
+      nscale = nscale + ns
+      wsp(iphih+mbrkdwn)   = hj1j*wsp(iphih+mx+mbrkdwn-1)
+      wsp(iphih+mbrkdwn+1) = hj1j*wsp(iphih+2*mx+mbrkdwn-1)
+ 
+ 402  continue
+* 
+*---  error estimate ...
+*
+      if ( k1.eq.0 ) then
+         err_loc = tol
+      else
+         p1 = ABS( wsp(iphih+m) )   * beta
+         p2 = ABS( wsp(iphih+m+1) ) * beta * avnorm 
+         if ( p1.gt.10.0d0*p2 ) then
+            err_loc = p2
+            xm = 1.0d0/DBLE( m+1 )
+         elseif ( p1.gt.p2 ) then
+            err_loc = (p1*p2)/(p1-p2)
+            xm = 1.0d0/DBLE( m+1 )
+         else
+            err_loc = p1
+            xm = 1.0d0/DBLE( m )
+         endif
+      endif
+*
+*---  reject the step-size if the error is not acceptable ...
+*   
+      if ( (k1.ne.0) .and. (err_loc.gt.delta*t_step*tol) .and. 
+     .     (mxreject.eq.0 .or. ireject.lt.mxreject) ) then
+         t_old = t_step
+         t_step = gamma * t_step * (t_step*tol/err_loc)**xm
+         p1 = 10.0d0**(NINT( LOG10( t_step )-SQR1 )-1)
+         t_step = AINT( t_step/p1 + 0.55d0 ) * p1
+         if ( itrace.ne.0 ) then
+            print*,'t_step =',t_old
+            print*,'err_loc =',err_loc
+            print*,'err_required =',delta*t_old*tol
+            print*,'stepsize rejected, stepping down to:',t_step
+         endif 
+         ireject = ireject + 1
+         nreject = nreject + 1
+         if ( mxreject.ne.0 .and. ireject.gt.mxreject ) then
+            print*,"Failure in DSPHIV: ---"
+            print*,"The requested tolerance is too high."
+            Print*,"Rerun with a smaller value."
+            iflag = 2
+            return
+         endif
+         goto 401
+      endif
+*
+      mx = mbrkdwn + MAX( 0,k1-2 )
+      call DGEMV( 'n', n,mx,beta,wsp(iv),n,wsp(iphih),1,1.0d0,w,1 )
+*
+*---  suggested value for the next stepsize ...
+*
+      t_new = gamma * t_step * (t_step*tol/err_loc)**xm
+      p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+      t_new = AINT( t_new/p1 + 0.55d0 ) * p1 
+
+      err_loc = MAX( err_loc,rndoff )
+*
+*---  update the time covered ...
+*
+      t_now = t_now + t_step 
+*
+*---  display and keep some information ...
+*
+      if ( itrace.ne.0 ) then
+         print*,'integration',nstep,'---------------------------------'
+         print*,'scale-square =',ns
+         print*,'step_size =',t_step
+         print*,'err_loc   =',err_loc
+         print*,'next_step =',t_new
+      endif
+
+      step_min = MIN( step_min, t_step ) 
+      step_max = MAX( step_max, t_step )
+      s_error = s_error + err_loc
+      x_error = MAX( x_error, err_loc )
+ 
+      if ( mxstep.eq.0 .or. nstep.lt.mxstep ) goto 100
+      iflag = 1
+ 
+ 500  continue
+
+      iwsp(1) = nmult
+      iwsp(2) = nexph
+      iwsp(3) = nscale
+      iwsp(4) = nstep
+      iwsp(5) = nreject
+      iwsp(6) = ibrkflag
+      iwsp(7) = mbrkdwn
+
+      wsp(1)  = step_min
+      wsp(2)  = step_max
+      wsp(3)  = 0.0d0
+      wsp(4)  = 0.0d0
+      wsp(5)  = x_error
+      wsp(6)  = s_error
+      wsp(7)  = tbrkdwn
+      wsp(8)  = sgn*t_now
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine ZGPHIV( n, m, t, u, v, w, tol, anorm,
+     .                   wsp,lwsp, iwsp,liwsp, matvec, itrace,iflag )
+
+      implicit none
+      integer          n, m, lwsp, liwsp, itrace, iflag, iwsp(liwsp)
+      double precision t, tol, anorm
+      complex*16       u(n), v(n), w(n), wsp(lwsp)
+      external         matvec
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  ZGPHIV computes w = exp(t*A)v + t*phi(tA)u which is the solution 
+*     of the nonhomogeneous linear ODE problem w' = Aw + u, w(0) = v.
+*     phi(z) = (exp(z)-1)/z and A is a Zomplex (i.e., complex double 
+*     precision matrix).
+*
+*     The method used is based on Krylov subspace projection
+*     techniques and the matrix under consideration interacts only
+*     via the external routine `matvec' performing the matrix-vector 
+*     product (matrix-free method).
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     n      : (input) order of the principal matrix A.
+*                      
+*     m      : (input) maximum size for the Krylov basis.
+*                      
+*     t      : (input) time at wich the solution is needed (can be < 0).
+*   
+*     u(n)   : (input) operand vector with respect to the phi function
+*              (forcing term of the ODE problem).
+*
+*     v(n)   : (input) operand vector with respect to the exp function
+*              (initial condition of the ODE problem).
+*  
+*     w(n)   : (output) computed approximation of exp(t*A)v + t*phi(tA)u 
+* 
+*     tol    : (input/output) the requested accuracy tolerance on w. 
+*              If on input tol=0.0d0 or tol is too small (tol.le.eps)
+*              the internal value sqrt(eps) is used, and tol is set to
+*              sqrt(eps) on output (`eps' denotes the machine epsilon).
+*              (`Happy breakdown' is assumed if h(j+1,j) .le. anorm*tol)
+*
+*     anorm  : (input) an approximation of some norm of A.
+*
+*   wsp(lwsp): (workspace) lwsp .ge. n*(m+1)+n+(m+3)^2+4*(m+3)^2+ideg+1
+*                                   +---------+-------+---------------+
+*              (actually, ideg=6)        V        H      wsp for PADE
+*                   
+* iwsp(liwsp): (workspace) liwsp .ge. m+3
+*
+*     matvec : external subroutine for matrix-vector multiplication.
+*              synopsis: matvec( x, y )
+*                        double precision x(*), y(*)
+*              computes: y(1:n) <- A*x(1:n)
+*                        where A is the principal matrix.
+*
+*     itrace : (input) running mode. 0=silent, 1=print step-by-step info
+*
+*     iflag  : (output) exit flag.
+*              <0 - bad input arguments
+*               0 - no problem
+*               1 - maximum number of steps reached without convergence
+*               2 - requested tolerance was too high
+*
+*-----Accounts on the computation--------------------------------------|
+*     Upon exit, an interested user may retrieve accounts on the 
+*     computations. They are located in the workspace arrays wsp and 
+*     iwsp as indicated below: 
+*
+*     location  mnemonic                 description
+*     -----------------------------------------------------------------|
+*     iwsp(1) = nmult, number of matrix-vector multiplications used
+*     iwsp(2) = nexph, number of Hessenberg matrix exponential evaluated
+*     iwsp(3) = nscale, number of repeated squaring involved in Pade
+*     iwsp(4) = nstep, number of integration steps used up to completion 
+*     iwsp(5) = nreject, number of rejected step-sizes
+*     iwsp(6) = ibrkflag, set to 1 if `happy breakdown' and 0 otherwise
+*     iwsp(7) = mbrkdwn, if `happy brkdown', basis-size when it occured
+*     -----------------------------------------------------------------|
+*     wsp(1)  = step_min, minimum step-size used during integration
+*     wsp(2)  = step_max, maximum step-size used during integration
+*     wsp(3)  = dummy
+*     wsp(4)  = dummy
+*     wsp(5)  = x_error, maximum among all local truncation errors
+*     wsp(6)  = s_error, global sum of local truncation errors
+*     wsp(7)  = tbrkdwn, if `happy breakdown', time when it occured
+*     wsp(8)  = t_now, integration domain successfully covered
+*
+*----------------------------------------------------------------------|
+*-----The following parameters may also be adjusted herein-------------|
+*
+      integer mxstep, mxreject, ideg
+      double precision delta, gamma
+      parameter( mxstep   = 500, 
+     .           mxreject = 0,
+     .           ideg     = 6, 
+     .           delta    = 1.2d0,
+     .           gamma    = 0.9d0 )
+
+*     mxstep  : maximum allowable number of integration steps.
+*               The value 0 means an infinite number of steps.
+* 
+*     mxreject: maximum allowable number of rejections at each step. 
+*               The value 0 means an infinite number of rejections.
+*
+*     ideg    : the Pade approximation of type (ideg,ideg) is used as 
+*               an approximation to exp(H).
+*
+*     delta   : local truncation error `safety factor'
+*
+*     gamma   : stepsize `shrinking factor'
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      complex*16 ZERO, ONE
+      parameter( ZERO=(0.0d0,0.0d0), ONE=(1.0d0,0.0d0) )
+      integer i, j, k1, mh, mx, iv, ih, j1v, ns, ifree, lfree, iexph,
+     .        ireject,ibrkflag,mbrkdwn, nmult, nreject, nexph, nscale,
+     .        nstep, iphih
+      double precision sgn, t_out, tbrkdwn, step_min,step_max, err_loc,
+     .                 s_error, x_error, t_now, t_new, t_step, t_old,
+     .                 xm, beta, break_tol, p1, p2, p3, eps, rndoff,
+     .                 avnorm, hj1j, SQR1
+      complex*16 hij
+
+      intrinsic AINT,ABS,CMPLX,DBLE,INT,LOG10,MAX,MIN,NINT,SIGN,SQRT
+      complex*16 ZDOTC
+      double precision DZNRM2
+*
+*---  check restrictions on input parameters ...
+*
+      iflag = 0
+      if ( lwsp.lt.n*(m+3)+5*(m+3)**2+ideg+1 ) iflag = -1
+      if ( liwsp.lt.m+3 ) iflag = -2
+      if ( m.ge.n .or. m.le.0 ) iflag = -3
+      if ( iflag.ne.0 ) stop 'bad sizes (in input of ZGPHIV)'
+*
+*---  initialisations ...
+*
+      k1 = 3
+      mh = m + 3
+      iv = 1 
+      ih = iv + n*(m+1) + n
+      ifree = ih + mh*mh
+      lfree = lwsp - ifree + 1
+
+      ibrkflag = 0
+      mbrkdwn  = m
+      nmult    = 0
+      nreject  = 0
+      nexph    = 0
+      nscale   = 0
+
+      t_out    = ABS( t )
+      tbrkdwn  = 0.0d0
+      step_min = t_out
+      step_max = 0.0d0
+      nstep    = 0
+      s_error  = 0.0d0
+      x_error  = 0.0d0
+      t_now    = 0.0d0
+      t_new    = 0.0d0
+
+      p1 = 4.0d0/3.0d0
+ 1    p2 = p1 - 1.0d0
+      p3 = p2 + p2 + p2
+      eps = ABS( p3-1.0d0 )
+      if ( eps.eq.0.0d0 ) go to 1
+      if ( tol.le.eps ) tol = SQRT( eps )
+      rndoff = eps*anorm
+
+      break_tol = 1.0d-7
+*>>>  break_tol = tol
+*>>>  break_tol = anorm*tol
+
+      sgn = SIGN( 1.0d0,t )
+      SQR1 = SQRT( 0.1d0 )
+      call ZCOPY( n, v,1, w,1 )
+*
+*---  step-by-step integration ...
+*
+ 100  if ( t_now.ge.t_out ) goto 500
+
+      nmult =  nmult + 1
+      call matvec( w, wsp(iv) )
+      call ZAXPY( n, ONE, u,1, wsp(iv),1 )
+      beta = DZNRM2( n, wsp(iv),1 )
+      if ( beta.eq.0.0d0 ) goto 500
+      call ZDSCAL( n, 1.0d0/beta, wsp(iv),1 )
+      do i = 1,mh*mh
+         wsp(ih+i-1) = ZERO
+      enddo
+
+      if ( nstep.eq.0 ) then
+*---     obtain the very first stepsize ...
+         xm = 1.0d0/DBLE( m )
+         p1 = tol*(((m+1)/2.72D0)**(m+1))*SQRT(2.0D0*3.14D0*(m+1))
+         t_new = (1.0d0/anorm)*(p1/(4.0d0*beta*anorm))**xm
+         p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+         t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+      endif
+      nstep = nstep + 1
+      t_step = MIN( t_out-t_now, t_new )
+*
+*---  Arnoldi loop ...
+*
+      j1v = iv + n
+      do 200 j = 1,m
+         nmult = nmult + 1
+         call matvec( wsp(j1v-n), wsp(j1v) )
+         do i = 1,j
+            hij = ZDOTC( n, wsp(iv+(i-1)*n),1, wsp(j1v),1 )
+            call ZAXPY( n, -hij, wsp(iv+(i-1)*n),1, wsp(j1v),1 )
+            wsp(ih+(j-1)*mh+i-1) = hij
+         enddo
+         hj1j = DZNRM2( n, wsp(j1v),1 )
+*---     if `happy breakdown' go straightforward at the end ... 
+         if ( hj1j.le.break_tol ) then
+            print*,'happy breakdown: mbrkdwn =',j,' h =',hj1j
+            k1 = 0
+            ibrkflag = 1
+            mbrkdwn = j
+            tbrkdwn = t_now
+            t_step = t_out-t_now
+            goto 300
+         endif
+         wsp(ih+(j-1)*mh+j) = CMPLX( hj1j )
+         call ZDSCAL( n, 1.0d0/hj1j, wsp(j1v),1 )
+         j1v = j1v + n
+ 200  continue
+      nmult = nmult + 1
+      call matvec( wsp(j1v-n), wsp(j1v) )
+      avnorm = DZNRM2( n, wsp(j1v),1 )
+*
+*---  set 1's for the 3-extended scheme ...
+*
+ 300  continue
+      wsp(ih+mh*mbrkdwn) = ONE
+      wsp(ih+(m-1)*mh+m) = ZERO
+      do i = 1,k1-1
+         wsp(ih+(m+i)*mh+m+i-1) = ONE
+      enddo
+*
+*---  loop while ireject<mxreject until the tolerance is reached ...
+*
+      ireject = 0
+ 401  continue
+*
+*---  compute w = beta*t_step*V*phi(t_step*H)*e1 + w
+*
+      nexph = nexph + 1
+      mx = mbrkdwn + MAX( 1,k1 )
+
+*---  irreducible rational Pade approximation ...
+      call ZGPADM( ideg, mx, sgn*t_step, wsp(ih),mh,
+     .             wsp(ifree),lfree, iwsp, iexph, ns, iflag )
+      iexph = ifree + iexph - 1
+      iphih = iexph + mbrkdwn*mx
+      nscale = nscale + ns
+      wsp(iphih+mbrkdwn)   = hj1j*wsp(iphih+mx+mbrkdwn-1)
+      wsp(iphih+mbrkdwn+1) = hj1j*wsp(iphih+2*mx+mbrkdwn-1)
+
+ 402  continue
+* 
+*---  error estimate ...
+* 
+      if ( k1.eq.0 ) then
+         err_loc = tol
+      else
+         p1 = ABS( wsp(iphih+m) )   * beta
+         p2 = ABS( wsp(iphih+m+1) ) * beta * avnorm 
+         if ( p1.gt.10.0d0*p2 ) then
+            err_loc = p2
+            xm = 1.0d0/DBLE( m+1 )
+         elseif ( p1.gt.p2 ) then
+            err_loc = (p1*p2)/(p1-p2)
+            xm = 1.0d0/DBLE( m+1 )
+         else
+            err_loc = p1
+            xm = 1.0d0/DBLE( m )
+         endif
+      endif
+*
+*---  reject the step-size if the error is not acceptable ...
+*   
+      if ( (k1.ne.0) .and. (err_loc.gt.delta*t_step*tol) .and.
+     .     (mxreject.eq.0 .or. ireject.lt.mxreject) ) then
+         t_old = t_step
+         t_step = gamma * t_step * (t_step*tol/err_loc)**xm
+         p1 = 10.0d0**(NINT( LOG10( t_step )-SQR1 )-1)
+         t_step = AINT( t_step/p1 + 0.55d0 ) * p1
+         if ( itrace.ne.0 ) then
+            print*,'t_step =',t_old
+            print*,'err_loc =',err_loc
+            print*,'err_required =',delta*t_old*tol
+            print*,'stepsize rejected, stepping down to:',t_step
+         endif
+         ireject = ireject + 1
+         nreject = nreject + 1
+         if ( mxreject.ne.0 .and. ireject.gt.mxreject ) then
+            print*,"Failure in ZGPHIV: ---"
+            print*,"The requested tolerance is too high."
+            Print*,"Rerun with a smaller value."
+            iflag = 2
+            return
+         endif
+         goto 401
+      endif
+*
+      mx = mbrkdwn + MAX( 0,k1-2 )
+      hij = CMPLX( beta )
+      call ZGEMV( 'n', n,mx,hij,wsp(iv),n,wsp(iphih),1,ONE,w,1 )
+*
+*---  suggested value for the next stepsize ...
+*
+      t_new = gamma * t_step * (t_step*tol/err_loc)**xm
+      p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+      t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+
+      err_loc = MAX( err_loc,rndoff )
+*
+*---  update the time covered ...
+*
+      t_now = t_now + t_step
+*
+*---  display and keep some information ...
+*
+      if ( itrace.ne.0 ) then
+         print*,'integration',nstep,'---------------------------------'
+         print*,'scale-square =',ns
+         print*,'step_size =',t_step
+         print*,'err_loc   =',err_loc
+         print*,'next_step =',t_new
+      endif
+
+      step_min = MIN( step_min, t_step )
+      step_max = MAX( step_max, t_step )
+      s_error = s_error + err_loc
+      x_error = MAX( x_error, err_loc )
+
+      if ( mxstep.eq.0 .or. nstep.lt.mxstep ) goto 100
+      iflag = 1
+
+ 500  continue
+
+      iwsp(1) = nmult
+      iwsp(2) = nexph
+      iwsp(3) = nscale
+      iwsp(4) = nstep
+      iwsp(5) = nreject
+      iwsp(6) = ibrkflag
+      iwsp(7) = mbrkdwn
+
+      wsp(1)  = CMPLX( step_min )
+      wsp(2)  = CMPLX( step_max )
+      wsp(3)  = CMPLX( 0.0d0 )
+      wsp(4)  = CMPLX( 0.0d0 )
+      wsp(5)  = CMPLX( x_error )
+      wsp(6)  = CMPLX( s_error )
+      wsp(7)  = CMPLX( tbrkdwn )
+      wsp(8)  = CMPLX( sgn*t_now )
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine ZHPHIV( n, m, t, u, v, w, tol, anorm,
+     .                   wsp,lwsp, iwsp,liwsp, matvec, itrace,iflag )
+
+      implicit none
+      integer          n, m, lwsp, liwsp, itrace, iflag, iwsp(liwsp)
+      double precision t, tol, anorm
+      complex*16       u(n), v(n), w(n), wsp(lwsp)
+      external         matvec
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  ZHPHIV computes w = exp(t*A)v + t*phi(tA)u which is the solution 
+*     of the nonhomogeneous linear ODE problem w' = Aw + u, w(0) = v.
+*     phi(z) = (exp(z)-1)/z and A is an Hermitian matrix.
+*
+*     The method used is based on Krylov subspace projection
+*     techniques and the matrix under consideration interacts only
+*     via the external routine `matvec' performing the matrix-vector 
+*     product (matrix-free method).
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     n      : (input) order of the principal matrix A.
+*                      
+*     m      : (input) maximum size for the Krylov basis.
+*                      
+*     t      : (input) time at wich the solution is needed (can be < 0).
+*   
+*     u(n)   : (input) operand vector with respect to the phi function
+*              (forcing term of the ODE problem).
+*
+*     v(n)   : (input) operand vector with respect to the exp function
+*              (initial condition of the ODE problem).
+*  
+*     w(n)   : (output) computed approximation of exp(t*A)v + t*phi(tA)u 
+* 
+*     tol    : (input/output) the requested accuracy tolerance on w. 
+*              If on input tol=0.0d0 or tol is too small (tol.le.eps)
+*              the internal value sqrt(eps) is used, and tol is set to
+*              sqrt(eps) on output (`eps' denotes the machine epsilon).
+*              (`Happy breakdown' is assumed if h(j+1,j) .le. anorm*tol)
+*
+*     anorm  : (input) an approximation of some norm of A.
+*
+*   wsp(lwsp): (workspace) lwsp .ge. n*(m+1)+n+(m+3)^2+4*(m+3)^2+ideg+1
+*                                   +---------+-------+---------------+
+*              (actually, ideg=6)        V        H      wsp for PADE
+*                   
+* iwsp(liwsp): (workspace) liwsp .ge. m+3
+*
+*     matvec : external subroutine for matrix-vector multiplication.
+*              synopsis: matvec( x, y )
+*                        double precision x(*), y(*)
+*              computes: y(1:n) <- A*x(1:n)
+*                        where A is the principal matrix.
+*
+*     itrace : (input) running mode. 0=silent, 1=print step-by-step info
+*
+*     iflag  : (output) exit flag.
+*              <0 - bad input arguments 
+*               0 - no problem
+*               1 - maximum number of steps reached without convergence
+*               2 - requested tolerance was too high
+*
+*-----Accounts on the computation--------------------------------------|
+*     Upon exit, an interested user may retrieve accounts on the 
+*     computations. They are located in the workspace arrays wsp and 
+*     iwsp as indicated below: 
+*
+*     location  mnemonic                 description
+*     -----------------------------------------------------------------|
+*     iwsp(1) = nmult, number of matrix-vector multiplications used
+*     iwsp(2) = nexph, number of Hessenberg matrix exponential evaluated
+*     iwsp(3) = nscale, number of repeated squaring involved in Pade
+*     iwsp(4) = nstep, number of integration steps used up to completion 
+*     iwsp(5) = nreject, number of rejected step-sizes
+*     iwsp(6) = ibrkflag, set to 1 if `happy breakdown' and 0 otherwise
+*     iwsp(7) = mbrkdwn, if `happy brkdown', basis-size when it occured
+*     -----------------------------------------------------------------|
+*     wsp(1)  = step_min, minimum step-size used during integration
+*     wsp(2)  = step_max, maximum step-size used during integration
+*     wsp(3)  = dummy
+*     wsp(4)  = dummy
+*     wsp(5)  = x_error, maximum among all local truncation errors
+*     wsp(6)  = s_error, global sum of local truncation errors
+*     wsp(7)  = tbrkdwn, if `happy breakdown', time when it occured
+*     wsp(8)  = t_now, integration domain successfully covered
+*
+*----------------------------------------------------------------------|
+*-----The following parameters may also be adjusted herein-------------|
+*
+      integer mxstep, mxreject, ideg
+      double precision delta, gamma
+      parameter( mxstep   = 500, 
+     .           mxreject = 0,
+     .           ideg     = 6, 
+     .           delta    = 1.2d0,
+     .           gamma    = 0.9d0 )
+
+*     mxstep  : maximum allowable number of integration steps.
+*               The value 0 means an infinite number of steps.
+* 
+*     mxreject: maximum allowable number of rejections at each step. 
+*               The value 0 means an infinite number of rejections.
+*
+*     ideg    : the Pade approximation of type (ideg,ideg) is used as 
+*               an approximation to exp(H).
+*
+*     delta   : local truncation error `safety factor'
+*
+*     gamma   : stepsize `shrinking factor'
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     EXPOKIT: Software Package for Computing Matrix Exponentials.
+*     ACM - Transactions On Mathematical Software, 24(1):130-156, 1998
+*----------------------------------------------------------------------|
+*
+      complex*16 ZERO, ONE
+      parameter( ZERO=(0.0d0,0.0d0), ONE=(1.0d0,0.0d0) )
+      integer i, j, k1, mh, mx, iv, ih, j1v, ns, ifree, lfree, iexph,
+     .        ireject,ibrkflag,mbrkdwn, nmult, nreject, nexph, nscale,
+     .        nstep, iphih
+      double precision sgn, t_out, tbrkdwn, step_min,step_max, err_loc,
+     .                 s_error, x_error, t_now, t_new, t_step, t_old,
+     .                 xm, beta, break_tol, p1, p2, p3, eps, rndoff,
+     .                 avnorm, hj1j, SQR1
+      complex*16 hjj
+
+      intrinsic AINT,ABS,CMPLX,DBLE,INT,LOG10,MAX,MIN,NINT,SIGN,SQRT
+      complex*16 ZDOTC
+      double precision DZNRM2
+*
+*---  check restrictions on input parameters ...
+*
+      iflag = 0
+      if ( lwsp.lt.n*(m+3)+5*(m+3)**2+ideg+1 ) iflag = -1
+      if ( liwsp.lt.m+3 ) iflag = -2
+      if ( m.ge.n .or. m.le.0 ) iflag = -3
+      if ( iflag.ne.0 ) stop 'bad sizes (in input of ZHPHIV)'
+*
+*---  initialisations ...
+*
+      k1 = 3
+      mh = m + 3
+      iv = 1 
+      ih = iv + n*(m+1) + n
+      ifree = ih + mh*mh
+      lfree = lwsp - ifree + 1
+
+      ibrkflag = 0
+      mbrkdwn  = m
+      nmult    = 0
+      nreject  = 0
+      nexph    = 0
+      nscale   = 0
+
+      t_out    = ABS( t )
+      tbrkdwn  = 0.0d0
+      step_min = t_out
+      step_max = 0.0d0
+      nstep    = 0
+      s_error  = 0.0d0
+      x_error  = 0.0d0
+      t_now    = 0.0d0
+      t_new    = 0.0d0
+
+      p1 = 4.0d0/3.0d0
+ 1    p2 = p1 - 1.0d0
+      p3 = p2 + p2 + p2
+      eps = ABS( p3-1.0d0 )
+      if ( eps.eq.0.0d0 ) go to 1
+      if ( tol.le.eps ) tol = SQRT( eps )
+      rndoff = eps*anorm
+
+      break_tol = 1.0d-7
+*>>>  break_tol = tol
+*>>>  break_tol = anorm*tol
+
+      sgn = SIGN( 1.0d0,t )
+      SQR1 = SQRT( 0.1d0 )
+      call ZCOPY( n, v,1, w,1 )
+*
+*---  step-by-step integration ...
+*
+ 100  if ( t_now.ge.t_out ) goto 500
+
+      nmult =  nmult + 1
+      call matvec( w, wsp(iv) )
+      call ZAXPY( n, ONE, u,1, wsp(iv),1 )
+      beta = DZNRM2( n, wsp(iv),1 )
+      if ( beta.eq.0.0d0 ) goto 500
+      call ZDSCAL( n, 1.0d0/beta, wsp(iv),1 )
+      do i = 1,mh*mh
+         wsp(ih+i-1) = ZERO
+      enddo
+
+      if ( nstep.eq.0 ) then
+*---     obtain the very first stepsize ...
+         xm = 1.0d0/DBLE( m )
+         p1 = tol*(((m+1)/2.72D0)**(m+1))*SQRT(2.0D0*3.14D0*(m+1))
+         t_new = (1.0d0/anorm)*(p1/(4.0d0*beta*anorm))**xm
+         p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+         t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+      endif
+      nstep = nstep + 1
+      t_step = MIN( t_out-t_now, t_new )
+*
+*---  Lanczos loop ...
+*
+      j1v = iv + n
+      do 200 j = 1,m
+         nmult = nmult + 1
+         call matvec( wsp(j1v-n), wsp(j1v) )
+         if ( j.gt.1 )
+     .     call ZAXPY(n,-wsp(ih+(j-1)*mh+j-2),wsp(j1v-2*n),1,wsp(j1v),1)
+         hjj = ZDOTC( n, wsp(j1v-n),1, wsp(j1v),1 )
+         call ZAXPY( n, -hjj, wsp(j1v-n),1, wsp(j1v),1 )
+         hj1j = DZNRM2( n, wsp(j1v),1 )
+         wsp(ih+(j-1)*(mh+1)) = hjj
+         if ( hj1j.le.break_tol ) then
+            print*,'happy breakdown: mbrkdwn =',j,' h =',hj1j
+            k1 = 0
+            ibrkflag = 1
+            mbrkdwn = j
+            tbrkdwn = t_now
+            t_step = t_out-t_now
+            goto 300
+         endif
+         wsp(ih+(j-1)*mh+j) = CMPLX( hj1j )
+         wsp(ih+j*mh+j-1) = CMPLX( hj1j )
+         call ZDSCAL( n, 1.0d0/hj1j, wsp(j1v),1 )
+         j1v = j1v + n
+ 200  continue
+      nmult = nmult + 1
+      call matvec( wsp(j1v-n), wsp(j1v) )
+      avnorm = DZNRM2( n, wsp(j1v),1 )
+*
+*---  set 1's for the 3-extended scheme ...
+*
+ 300  continue
+      wsp(ih+mh*mbrkdwn) = ONE
+      wsp(ih+m*mh+m-1)   = ZERO
+      wsp(ih+(m-1)*mh+m) = ZERO
+      do i = 1,k1-1
+         wsp(ih+(m+i)*mh+m+i-1) = ONE
+      enddo
+*
+*---  loop while ireject<mxreject until the tolerance is reached ...
+*
+      ireject = 0
+ 401  continue
+*
+*---  compute w = beta*t_step*V*phi(t_step*H)*e1 + w
+*
+      nexph = nexph + 1
+      mx = mbrkdwn + MAX( 1,k1 )
+
+*---  irreducible rational Pade approximation ...
+      call ZGPADM( ideg, mx, sgn*t_step, wsp(ih),mh,
+     .              wsp(ifree),lfree, iwsp, iexph, ns, iflag )
+      iexph = ifree + iexph - 1
+      iphih = iexph + mbrkdwn*mx
+      nscale = nscale + ns
+      wsp(iphih+mbrkdwn)   = hj1j*wsp(iphih+mx+mbrkdwn-1)
+      wsp(iphih+mbrkdwn+1) = hj1j*wsp(iphih+2*mx+mbrkdwn-1)
+
+ 402  continue
+* 
+*---  error estimate ...
+* 
+      if ( k1.eq.0 ) then
+         err_loc = tol
+      else
+         p1 = ABS( wsp(iphih+m) )   * beta
+         p2 = ABS( wsp(iphih+m+1) ) * beta * avnorm 
+         if ( p1.gt.10.0d0*p2 ) then
+            err_loc = p2
+            xm = 1.0d0/DBLE( m+1 )
+         elseif ( p1.gt.p2 ) then
+            err_loc = (p1*p2)/(p1-p2)
+            xm = 1.0d0/DBLE( m+1 )
+         else
+            err_loc = p1
+            xm = 1.0d0/DBLE( m )
+         endif
+      endif
+*
+*---  reject the step-size if the error is not acceptable ...
+*   
+      if ( (k1.ne.0) .and. (err_loc.gt.delta*t_step*tol) .and.
+     .     (mxreject.eq.0 .or. ireject.lt.mxreject) ) then
+         t_old = t_step
+         t_step = gamma * t_step * (t_step*tol/err_loc)**xm
+         p1 = 10.0d0**(NINT( LOG10( t_step )-SQR1 )-1)
+         t_step = AINT( t_step/p1 + 0.55d0 ) * p1
+         if ( itrace.ne.0 ) then
+            print*,'t_step =',t_old
+            print*,'err_loc =',err_loc
+            print*,'err_required =',delta*t_old*tol
+            print*,'stepsize rejected, stepping down to:',t_step
+         endif
+         ireject = ireject + 1
+         nreject = nreject + 1
+         if ( mxreject.ne.0 .and. ireject.gt.mxreject ) then
+            print*,"Failure in ZHPHIV: ---"
+            print*,"The requested tolerance is too high."
+            Print*,"Rerun with a smaller value."
+            iflag = 2
+            return
+         endif
+         goto 401
+      endif
+*
+      mx = mbrkdwn + MAX( 0,k1-2 )
+      hjj = CMPLX( beta )
+      call ZGEMV( 'n', n,mx,hjj,wsp(iv),n,wsp(iphih),1,ONE,w,1 )
+*
+*---  suggested value for the next stepsize ...
+*
+      t_new = gamma * t_step * (t_step*tol/err_loc)**xm
+      p1 = 10.0d0**(NINT( LOG10( t_new )-SQR1 )-1)
+      t_new = AINT( t_new/p1 + 0.55d0 ) * p1
+
+      err_loc = MAX( err_loc,rndoff )
+*
+*---  update the time covered ...
+*
+      t_now = t_now + t_step
+*
+*---  display and keep some information ...
+*
+      if ( itrace.ne.0 ) then
+         print*,'integration',nstep,'---------------------------------'
+         print*,'scale-square =',ns
+         print*,'step_size =',t_step
+         print*,'err_loc   =',err_loc
+         print*,'next_step =',t_new
+      endif
+
+      step_min = MIN( step_min, t_step )
+      step_max = MAX( step_max, t_step )
+      s_error = s_error + err_loc
+      x_error = MAX( x_error, err_loc )
+
+      if ( mxstep.eq.0 .or. nstep.lt.mxstep ) goto 100
+      iflag = 1
+
+ 500  continue
+
+      iwsp(1) = nmult
+      iwsp(2) = nexph
+      iwsp(3) = nscale
+      iwsp(4) = nstep
+      iwsp(5) = nreject
+      iwsp(6) = ibrkflag
+      iwsp(7) = mbrkdwn
+
+      wsp(1)  = CMPLX( step_min )
+      wsp(2)  = CMPLX( step_max )
+      wsp(3)  = CMPLX( 0.0d0 )
+      wsp(4)  = CMPLX( 0.0d0 )
+      wsp(5)  = CMPLX( x_error )
+      wsp(6)  = CMPLX( s_error )
+      wsp(7)  = CMPLX( tbrkdwn )
+      wsp(8)  = CMPLX( sgn*t_now )
+      END
+*----------------------------------------------------------------------|

--- a/src/expokit/mataid.f
+++ b/src/expokit/mataid.f
@@ -1,0 +1,1275 @@
+*-------------------------------NOTE-----------------------------------*
+*     This is an accessory to Expokit and it is not intended to be     *
+*     complete. It is supplied primarily to ensure an unconstrained    *
+*     distribution and portability of the package. The matrix-vector   *
+*     multiplication routines supplied here fit the non symmetric      *
+*     storage and for a symmetric matrix, the entire (not half) matrix *
+*     is required.  If the sparsity pattern is known a priori, it is   *
+*     recommended to use the most advantageous format and to devise    *
+*     the most advantageous matrix-vector multiplication routine.      *
+*----------------------------------------------------------------------*
+*----------------------------------------------------------------------*
+      subroutine dgcoov ( x, y )
+      implicit none
+      double precision x(*), y(*)
+*
+*---  Computes y = A*x. A is passed via a fortran `common statement'.
+*---  A is assumed here to be under the COOrdinates storage format.
+*
+      integer n, nz, nzmax
+      parameter( nzmax = 600000 )
+      integer ia(nzmax), ja(nzmax)
+      double precision a(nzmax)
+      common /RMAT/ a, ia, ja, nz, n
+      integer i, j
+ 
+      do j = 1,n
+         y(j) = 0.0d0
+      enddo
+      do i = 1,nz
+         y(ia(i)) = y(ia(i)) + a(i)*x(ja(i))
+      enddo
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine dgcrsv ( x, y )
+      implicit none
+      double precision x(*), y(*)
+*
+*---  Computes y = A*x. A is passed via a fortran `common statement'.
+*---  A is assumed to be under the Compress Row Storage (CRS) format.
+*
+      integer n, nz, nzmax
+      parameter( nzmax = 600000 )
+      integer ia(nzmax), ja(nzmax)
+      double precision a(nzmax)
+      common /RMAT/ a, ia, ja, nz, n
+      integer i, j
+
+      do i = 1,n
+         y(i) = 0.0d0
+         do j = ia(i),ia(i+1)-1
+            y(i) = y(i) + a(j)*x(ja(j))
+         enddo
+      enddo
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine dgccsv( x, y )
+      implicit none
+      double precision x(*), y(*)
+*
+*---  Computes y = A*x. A is passed via a fortran `common statement'.
+*---  A is assumed to be under the Compress Column Storage (CCS) format.
+*
+      integer n, nz, nzmax
+      parameter( nzmax = 600000 )
+      integer ia(nzmax), ja(nzmax)
+      double precision a(nzmax)
+      common /RMAT/ a, ia, ja, nz, n
+      integer i, j
+
+      do i = 1,n
+         y(i) = 0.0d0
+      enddo
+      do j = 1,n
+         do i = ja(j),ja(j+1)-1
+            y(ia(i)) = y(ia(i)) + a(i)*x(j)
+         enddo
+      enddo
+      end
+*----------------------------------------------------------------------|
+
+*-------------------------------NOTE-----------------------------------*
+*     This is an accessory to Expokit and it is not intended to be     *
+*     complete. It is supplied primarily to ensure an unconstrained    *
+*     distribution and portability of the package. The matrix-vector   *
+*     multiplication routines supplied here fit the non symmetric      *
+*     storage and for a symmetric matrix, the entire (not half) matrix *
+*     is required.  If the sparsity pattern is known a priori, it is   *
+*     recommended to use the most advantageous format and to devise    *
+*     the most advantageous matrix-vector multiplication routine.      *
+*----------------------------------------------------------------------*
+*----------------------------------------------------------------------*
+      subroutine zgcoov ( x, y )
+      implicit none
+      complex*16 x(*), y(*)
+*
+*---  Computes y = A*x. A is passed via a fortran `common statement'.
+*---  A is assumed here to be under the COOrdinates storage format.
+*
+      integer n, nz, nzmax
+      parameter( nzmax = 50000 )
+      integer ia(nzmax), ja(nzmax)
+      complex*16 a(nzmax)
+      common /CMAT/ a, ia, ja, nz, n
+
+      integer i, j
+      complex*16 ZERO
+      parameter( ZERO=(0.0d0,0.0d0) )
+ 
+      do j = 1,n
+         y(j) = ZERO
+      enddo
+      do i = 1,nz
+         y(ia(i)) = y(ia(i)) + a(i)*x(ja(i))
+      enddo
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine zgcrsv ( x, y )
+      implicit none
+      complex*16 x(*), y(*)
+*
+*---  Computes y = A*x. A is passed via a fortran `common statement'.
+*---  A is assumed to be under the Compress Row Storage (CRS) format.
+*
+      integer n, nz, nzmax
+      parameter( nzmax = 50000 )
+      integer ia(nzmax), ja(nzmax)
+      complex*16 a(nzmax)
+      common /CMAT/ a, ia, ja, nz, n
+
+      integer i, j
+      complex*16 ZERO
+      parameter( ZERO=(0.0d0,0.0d0) )
+
+      do i = 1,n
+         y(i) = ZERO
+         do j = ia(i),ia(i+1)-1
+            y(i) = y(i) + a(j)*x(ja(j))
+         enddo
+      enddo
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine zgccsv( x, y )
+      implicit none
+      complex*16 x(*), y(*)
+*
+*---  Computes y = A*x. A is passed via a fortran `common statement'.
+*---  A is assumed to be under the Compress Column Storage (CCS) format.
+*
+      integer n, nz, nzmax
+      parameter( nzmax = 50000 )
+      integer ia(nzmax), ja(nzmax)
+      complex*16 a(nzmax)
+      common /CMAT/ a, ia, ja, nz, n
+
+      integer i, j
+      complex*16 ZERO
+      parameter( ZERO=(0.0d0,0.0d0) )
+
+      do i = 1,n
+         y(i) = ZERO
+      enddo
+      do j = 1,n
+         do i = ja(j),ja(j+1)-1
+            y(ia(i)) = y(ia(i)) + a(i)*x(j)
+         enddo
+      enddo
+      end
+*----------------------------------------------------------------------|
+
+*----------------------------------------------------------------------|
+      subroutine DGCNVR( from,to,diag, nrow,ncol, nz, ia, ja, a, iwsp )
+ 
+      implicit none
+      character        from*3, to*3, diag*1
+      integer          nrow, ncol, nz, ia(*), ja(*), iwsp(*)
+      double precision a(*)
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  DGCNVR converts a sparse storage format into another sparse
+*     storage format. The matrix can be rectangular.
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     from   : (input, character*3) the storage format holding the
+*              matrix on input. Accepted values are:
+*              'COO' : COOrdinates
+*              'CRS' : Compressed Row Storage
+*              'CCS' : Compressed Column Storage.
+*
+*     to     : (input, character*3) the storage format holding the
+*              matrix on output. Same accepted values as above.
+*
+*     diag   : (input, character*1) specifies whether or not the 
+*              entire diagonal should be lodged, i.e., including 
+*              null diagonal entries. (This may be required by
+*              some applications that make use of the locations
+*              of diagonal elements.)
+*              diag = 'N', no specific attention is given to diagonal 
+*                          elements.
+*              diag = 'D', the entire diagonal is lodged, including 
+*                          null elements on the diagonal.
+*              if from=to & diag='D', null diagonal entries are
+*              explicitly inserted in the actual matrix.
+*
+*     nrow   : (input) number of rows in the matrix.
+*
+*     ncol   : (input) number of columns in the matrix.
+*
+*     nz     : (input/output) number of non-zeros elements.
+*              If diag='D' and null diagonal entries are inserted, then 
+*              nz is updated on exit and contains the effective number
+*              of entries stored. In what follows, nz' (read nz prime)
+*              denotes the updated value of nz, nz <= nz' <= nz+n.
+*              If diag='N' then nz'=nz.
+*
+*     ia(*) : (input/output) of declared length .ge. nz'.
+*             On input, 
+*                if from='CRS', ia(1:nrow+1) contains pointers for the 
+*                beginning of each row. 
+*                if from='COO', or 'CCS', ia(1:nz) contains row indices.
+*             On output,
+*                if to='CRS', ia(1:nrow+1) contains pointers for the 
+*                beginning of each row. 
+*                if to='COO' or 'CCS', ia(1:nz') contains row indices
+*                in increasing order in each column.
+*
+*     ja(*) : (input/output) of declared length .ge. nz'.
+*             On input, 
+*                if from='CRS', ja(1:ncol+1) contains pointers for the 
+*                beginning of each column. 
+*                if from='COO' or 'CCS', ja(1:nz) contains col. indices.
+*             On output,
+*                if to='CRS', ja(1:ncol+1) contains pointers for the 
+*                beginning of each column. 
+*                if to='COO' or 'CCS', ja(1:nz') contains column indices
+*                in increasing order in each row.
+*
+*     a(*)  : (input/output) On input, a(1:nz) fits the input format
+*             and on output, a(1:nz') fits the output format.
+*
+*   iwsp(*) : (workspace) of declared length .ge. max(nrow,ncol).
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     Department of Mathematics, University of Queensland. 
+*     Brisbane QLD 4072, Australia. 1996. 
+*----------------------------------------------------------------------|
+
+      integer i, j, k, nn, iflag
+      character cpy_from*3, cpy_to*3, cpy_diag*1, c*1, S1*3, S2*3 
+      logical LSAME
+
+      intrinsic CHAR,ICHAR,LLE,LGE,MIN
+      LSAME(S1,S2) = LLE(S1,S2).and.LGE(S1,S2)
+*
+*---  upper case strings ...
+*
+      do k = 1,3
+         c = from(k:k)
+         if ( c.ge.'a' .and. c.le.'z' ) c = CHAR( ICHAR(c)-32 )
+         cpy_from(k:k) = c
+         c = to(k:k)
+         if ( c.ge.'a' .and. c.le.'z' ) c = CHAR( ICHAR(c)-32 )
+         cpy_to(k:k) = c
+      enddo
+      c = diag(1:1)
+      if ( c.ge.'a' .and. c.le.'z' ) c = CHAR( ICHAR(c)-32 )
+      cpy_diag = c
+
+*---  quick return if possible ...
+      if ( LSAME(cpy_from,cpy_to) .and. cpy_diag.eq.'N' ) return
+      iflag = 1
+      if ( LSAME(cpy_from,'COO') ) iflag = 0
+      if ( LSAME(cpy_from,'CRS') ) iflag = 0
+      if ( LSAME(cpy_from,'CCS') ) iflag = 0
+      if ( iflag.ne.0 ) stop 'unexpected i/o formats (in DGCNVR)'
+      iflag = 1
+      if ( LSAME(cpy_to,'COO') )   iflag = 0
+      if ( LSAME(cpy_to,'CRS') )   iflag = 0
+      if ( LSAME(cpy_to,'CCS') )   iflag = 0
+      if ( iflag.ne.0 ) stop 'unexpected i/o formats (in DGCNVR)'
+
+*
+*---  transit via COOrdinates format if input is not in COO ...
+*
+      if ( LSAME(cpy_from,'CRS') ) then
+*---     expand ia indices ...
+         nn = nz
+         do i = nrow,1,-1
+            do k = 1,ia(i+1)-ia(i)
+               ia(nn) = i
+               nn = nn-1
+            enddo
+         enddo 
+      endif
+      if ( LSAME(cpy_from,'CCS') ) then
+*---     expand ja indices ...
+         nn = nz
+         do j = ncol,1,-1
+            do k = 1,ja(j+1)-ja(j)
+               ja(nn) = j
+               nn = nn-1
+            enddo
+         enddo 
+      endif
+*
+*--   if requested, insert diagonal elements even if they are zero...
+*
+      if ( cpy_diag.eq.'D' ) then
+         nn = MIN( nrow,ncol )
+         do i = 1,nn
+            iwsp(i) = 0
+         enddo
+         do k = 1,nz
+            if ( ia(k).eq.ja(k) ) iwsp(ia(k)) = 1
+         enddo
+         do i = 1,nn
+            if ( iwsp(i).eq.0 ) then
+               nz = nz + 1
+               ia(nz) = i
+               ja(nz) = i
+               a(nz) = 0.0d0
+            endif
+         enddo
+      endif
+
+*---  COO convertion ...
+      if ( LSAME(cpy_to,'COO') ) return
+
+*---  CRS convertion ...
+      if ( LSAME(cpy_to,'CRS') ) call dcmpac( nrow,nz,ia,ja,a, iwsp )
+
+*---  CCS convertion ...
+      if ( LSAME(cpy_to,'CCS') ) call dcmpac( ncol,nz,ja,ia,a, iwsp )
+
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+*
+      subroutine dcmpac( n, nx, ix, ixx, xx, iwsp )
+*--   DCMPAC compacts the array ix and sorts ixx and xx
+*--   (This is a gateway routine for DGCNVR) ...
+*----------------------------------------------------------------------|
+
+      implicit none
+      integer          n, nx, ix(nx), ixx(nx), iwsp(n)
+      double precision xx(nx)
+      integer          k
+*
+*---  sort ix and carry ixx and xx along ...
+*
+      call idsrt2( nx, ix, ixx, xx )
+*
+*---  adjust pointers ...
+*
+      do k = 1,n
+         iwsp(k) = 0
+      enddo
+      do k = 1,nx
+         iwsp(ix(k)) = iwsp(ix(k)) + 1
+      enddo
+      ix(n+1) = nx + 1
+      do k = n,1,-1
+         ix(k) = ix(k+1)-iwsp(k)
+      enddo
+* 
+*---  sort ixx in increasing order and carry xx along ...
+*
+      do k = 1,n
+         call idsrt1( iwsp(k), ixx(ix(k)), xx(ix(k)) )
+      enddo
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+*
+      subroutine idsrt1( nx, ix, xx )
+
+*---  IDSRT1: indirect sort -- sort ix and carry xx along
+*---  adapted from a SLAP (Sparse Linear Algebra Package) code.
+*----------------------------------------------------------------------|
+
+      implicit none
+      integer          nx, ix(nx)
+      double precision xx(nx)
+
+      integer          M,I,J,K,IL(21),IU(21), IT,IIT,IJ,L
+      double precision TX, TTX, R
+
+      if ( nx.le.1 ) return
+
+*---  And now...Just a little black magic...
+      M = 1
+      I = 1
+      J = NX
+      R = .375
+ 210  IF( R.LE.0.5898437 ) THEN
+         R = R + 3.90625E-2
+      ELSE
+         R = R-.21875
+      ENDIF
+ 225  K = I
+*
+*---  Select a central element of the array and save it in location 
+*---  IT, TX.
+*
+      IJ = I + IDINT( DBLE(J-I)*R )
+      IT = IX(IJ)
+      TX = XX(IJ)
+*
+*---  If first element of array is greater than IT, interchange with IT.
+*
+      IF( IX(I).GT.IT ) THEN
+         IX(IJ) = IX(I)
+         IX(I)  = IT
+         IT     = IX(IJ)
+         XX(IJ)  = XX(I)
+         XX(I)   = TX
+         TX     = XX(IJ)
+      ENDIF
+      L=J
+*                           
+*---  If last element of array is less than IT, swap with IT.
+*
+      IF( IX(J).LT.IT ) THEN
+         IX(IJ) = IX(J)
+         IX(J)  = IT
+         IT     = IX(IJ)
+         XX(IJ)  = XX(J)
+         XX(J)   = TX
+         TX     = XX(IJ)
+*
+*---  If first element of array is greater than IT, swap with IT.
+*
+         IF ( IX(I).GT.IT ) THEN
+            IX(IJ) = IX(I)
+            IX(I)  = IT
+            IT     = IX(IJ)
+            XX(IJ)  = XX(I)
+            XX(I)   = TX
+            TX     = XX(IJ)
+         ENDIF
+      ENDIF
+*
+*---  Find an element in the second half of the array which is 
+*---  smaller than IT.
+*
+ 240  L=L-1
+      IF( IX(L).GT.IT ) GO TO 240
+*
+*---  Find an element in the first half of the array which is 
+*---  greater than IT.
+*
+ 245  K=K+1
+      IF( IX(K).LT.IT ) GO TO 245
+*
+*---  Interchange these elements.
+*
+      IF( K.LE.L ) THEN
+         IIT   = IX(L)
+         IX(L) = IX(K)
+         IX(K) = IIT
+         TTX   = XX(L)
+         XX(L)  = XX(K)
+         XX(K)  = TTX
+         GOTO 240
+      ENDIF
+*
+*---  Save upper and lower subscripts of the array yet to be sorted.
+*
+      IF( L-I.GT.J-K ) THEN
+         IL(M) = I
+         IU(M) = L
+         I = K
+         M = M+1
+      ELSE
+         IL(M) = K
+         IU(M) = J
+         J = L
+         M = M+1
+      ENDIF
+      GO TO 260
+*
+*---  Begin again on another portion of the unsorted array.
+*
+ 255  M = M-1
+      IF( M.EQ.0 ) GO TO 300
+      I = IL(M)
+      J = IU(M)
+ 260  IF( J-I.GE.1 ) GO TO 225
+      IF( I.EQ.J ) GO TO 255
+      IF( I.EQ.1 ) GO TO 210
+      I = I-1
+ 265  I = I+1
+      IF( I.EQ.J ) GO TO 255
+      IT = IX(I+1)
+      TX =  XX(I+1)
+      IF( IX(I).LE.IT ) GO TO 265
+      K=I
+ 270  IX(K+1) = IX(K)
+      XX(K+1)  =  XX(K)
+      K = K-1
+      IF( IT.LT.IX(K) ) GO TO 270
+      IX(K+1) = IT
+      XX(K+1)  = TX
+      GO TO 265
+
+ 300  CONTINUE
+      RETURN
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine idsrt2( nx, ix, ixx, xx )
+
+*---  IDSRT2: indirect sort: sort ix and carry ixx and xx along
+*---  adapted from a SLAP (Sparse Linear Algebra Package) code.
+*----------------------------------------------------------------------|
+
+      implicit none
+      integer          nx, ix(nx), ixx(nx)
+      double precision xx(nx)
+
+      integer          M,I,J,K,IL(21),IU(21), IT,IIT,IJ,JT,JJT,L
+      double precision TX, TTX, R
+
+      if ( nx.le.1 ) return
+
+*---  And now...Just a little black magic...
+      M = 1
+      I = 1
+      J = NX
+      R = .375
+ 210  IF( R.LE.0.5898437 ) THEN
+         R = R + 3.90625E-2
+      ELSE
+         R = R-.21875
+      ENDIF
+ 225  K = I
+*
+*---  Select a central element of the array and save it in location 
+*---  IT, JT, TX.
+*
+      IJ = I + IDINT( DBLE(J-I)*R )
+      IT = IX(IJ)
+      JT = IXX(IJ)
+      TX = XX(IJ)
+*
+*---  If first element of array is greater than IT, interchange with IT.
+*
+      IF( IX(I).GT.IT ) THEN
+         IX(IJ) = IX(I)
+         IX(I)  = IT
+         IT     = IX(IJ)
+         IXX(IJ)= IXX(I)
+         IXX(I) = JT
+         JT     = IXX(IJ)
+         XX(IJ) = XX(I)
+         XX(I)  = TX
+         TX     = XX(IJ)
+      ENDIF
+      L=J
+*                           
+*---  If last element of array is less than IT, swap with IT.
+*
+      IF( IX(J).LT.IT ) THEN
+         IX(IJ) = IX(J)
+         IX(J)  = IT
+         IT     = IX(IJ)
+         IXX(IJ)= IXX(J)
+         IXX(J) = JT
+         JT     = IXX(IJ)
+         XX(IJ) = XX(J)
+         XX(J)  = TX
+         TX     = XX(IJ)
+*
+*---  If first element of array is greater than IT, swap with IT.
+*
+         IF ( IX(I).GT.IT ) THEN
+            IX(IJ) = IX(I)
+            IX(I)  = IT
+            IT     = IX(IJ)
+            IXX(IJ)= IXX(I)
+            IXX(I) = JT
+            JT     = IXX(IJ)
+            XX(IJ) = XX(I)
+            XX(I)  = TX
+            TX     = XX(IJ)
+         ENDIF
+      ENDIF
+*
+*---  Find an element in the second half of the array which is 
+*---  smaller than IT.
+*
+ 240  L=L-1
+      IF( IX(L).GT.IT ) GO TO 240
+*
+*---  Find an element in the first half of the array which is 
+*---  greater than IT.
+*
+ 245  K=K+1
+      IF( IX(K).LT.IT ) GO TO 245
+*
+*---  Interchange these elements.
+*
+      IF( K.LE.L ) THEN
+         IIT   = IX(L)
+         IX(L) = IX(K)
+         IX(K) = IIT
+         JJT   = IXX(L)
+         IXX(L)= IXX(K)
+         IXX(K)= JJT
+         TTX   = XX(L)
+         XX(L) = XX(K)
+         XX(K) = TTX
+         GOTO 240
+      ENDIF
+*
+*---  Save upper and lower subscripts of the array yet to be sorted.
+*
+      IF( L-I.GT.J-K ) THEN
+         IL(M) = I
+         IU(M) = L
+         I = K
+         M = M+1
+      ELSE
+         IL(M) = K
+         IU(M) = J
+         J = L
+         M = M+1
+      ENDIF
+      GO TO 260
+*
+*---  Begin again on another portion of the unsorted array.
+*
+ 255  M = M-1
+      IF( M.EQ.0 ) GO TO 300
+      I = IL(M)
+      J = IU(M)
+ 260  IF( J-I.GE.1 ) GO TO 225
+      IF( I.EQ.J ) GO TO 255
+      IF( I.EQ.1 ) GO TO 210
+      I = I-1
+ 265  I = I+1
+      IF( I.EQ.J ) GO TO 255
+      IT = IX(I+1)
+      JT = IXX(I+1)
+      TX =  XX(I+1)
+      IF( IX(I).LE.IT ) GO TO 265
+      K=I
+ 270  IX(K+1) = IX(K)
+      IXX(K+1) = IXX(K)
+      XX(K+1)  =  XX(K)
+      K = K-1
+      IF( IT.LT.IX(K) ) GO TO 270
+      IX(K+1) = IT
+      IXX(K+1) = JT
+      XX(K+1)  = TX
+      GO TO 265
+
+ 300  CONTINUE
+      RETURN
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine ZGCNVR( from,to,diag, nrow,ncol, nz, ia, ja, a, iwsp )
+ 
+      implicit none
+      character        from*3, to*3, diag*1
+      integer          nrow, ncol, nz, ia(*), ja(*), iwsp(*)
+      complex*16       a(*)
+
+*-----Purpose----------------------------------------------------------|
+*
+*---  ZGCNVR transforms a sparse storage format into another sparse
+*     storage format. The matrix can be rectangular.
+*     This is the complex counterpart of DGCNVR.
+*
+*-----Arguments--------------------------------------------------------|
+*
+*     from   : (input, character*3) the storage format holding the
+*              matrix on input. Accepted values are:
+*              'COO' : COOrdinates
+*              'CRS' : Compressed Row Storage
+*              'CCS' : Compressed Column Storage.
+*
+*     to     : (input, character*3) the storage format holding the
+*              matrix on output. Same accepted values as above.
+*
+*     diag   : (input, character*1) specifies whether or not the 
+*              entire diagonal should be lodged, i.e., including 
+*              null diagonal entries. (This may be required by
+*              some applications that make use of the locations
+*              of diagonal elements.)
+*              diag = 'N', no specific attention is given to diagonal 
+*                          elements.
+*              diag = 'D', the entire diagonal is lodged, including 
+*                          null elements on the diagonal.
+*              if from=to & diag='D', null diagonal entries are
+*              explicitly inserted in the actual matrix.
+*
+*     nrow   : (input) number of rows in the matrix.
+*
+*     ncol   : (input) number of columns in the matrix.
+*
+*     nz     : (input/output) number of non-zeros elements.
+*              If diag='D' and null diagonal entries are inserted, then 
+*              nz is updated on exit and contains the effective number
+*              of entries stored. In what follows, nz' (read nz prime)
+*              denotes the updated value of nz, nz <= nz' <= nz+n.
+*              If diag='N' then nz'=nz.
+*
+*     ia(*) : (input/output) of declared length .ge. nz'.
+*             On input, 
+*                if from='CRS', ia(1:nrow+1) contains pointers for the 
+*                beginning of each row. 
+*                if from='COO', or 'CCS', ia(1:nz) contains row indices.
+*             On output,
+*                if to='CRS', ia(1:nrow+1) contains pointers for the 
+*                beginning of each row. 
+*                if to='COO' or 'CCS', ia(1:nz') contains row indices
+*                in increasing order in each column.
+*
+*     ja(*) : (input/output) of declared length .ge. nz'.
+*             On input, 
+*                if from='CRS', ja(1:ncol+1) contains pointers for the 
+*                beginning of each column. 
+*                if from='COO' or 'CCS', ja(1:nz) contains col. indices.
+*             On output,
+*                if to='CRS', ja(1:ncol+1) contains pointers for the 
+*                beginning of each column. 
+*                if to='COO' or 'CCS', ja(1:nz') contains column indices
+*                in increasing order in each row.
+*
+*     a(*)  : (input/output) On input, a(1:nz) fits the input format
+*             and on output, a(1:nz') fits the output format.
+*
+*   iwsp(*) : (workspace) of declared length .ge. max(nrow,ncol).
+*
+*----------------------------------------------------------------------|
+*     Roger B. Sidje (rbs@maths.uq.edu.au)
+*     Department of Mathematics, University of Queensland. 
+*     Brisbane QLD 4072, Australia. 1996.
+*----------------------------------------------------------------------|
+
+      integer i, j, k, nn, iflag
+      character cpy_from*3, cpy_to*3, cpy_diag*1, c*1, S1*3, S2*3 
+      logical LSAME
+
+      intrinsic CHAR,ICHAR,LLE,LGE,MIN
+      LSAME(S1,S2) = LLE(S1,S2).and.LGE(S1,S2)
+*
+*---  upper case strings ...
+*
+      do k = 1,3
+         c = from(k:k)
+         if ( c.ge.'a' .and. c.le.'z' ) c = CHAR( ICHAR(c)-32 )
+         cpy_from(k:k) = c
+         c = to(k:k)
+         if ( c.ge.'a' .and. c.le.'z' ) c = CHAR( ICHAR(c)-32 )
+         cpy_to(k:k) = c
+      enddo
+      c = diag(1:1)
+      if ( c.ge.'a' .and. c.le.'z' ) c = CHAR( ICHAR(c)-32 )
+      cpy_diag = c
+
+*---  quick return if possible ...
+      if ( LSAME(cpy_from,cpy_to) .and. cpy_diag.eq.'N' ) return
+      iflag = 1
+      if ( LSAME(cpy_from,'COO') ) iflag = 0
+      if ( LSAME(cpy_from,'CRS') ) iflag = 0
+      if ( LSAME(cpy_from,'CCS') ) iflag = 0
+      if ( iflag.ne.0 ) stop 'unexpected i/o formats (in ZGCNVR)'
+      iflag = 1
+      if ( LSAME(cpy_to,'COO') )   iflag = 0
+      if ( LSAME(cpy_to,'CRS') )   iflag = 0
+      if ( LSAME(cpy_to,'CCS') )   iflag = 0
+      if ( iflag.ne.0 ) stop 'unexpected i/o formats (in ZGCNVR)'
+
+*
+*---  transit via COOrdinates format if input is not in COO ...
+*
+      if ( LSAME(cpy_from,'CRS') ) then
+*---     expand ia indices ...
+         nn = nz
+         do i = nrow,1,-1
+            do k = 1,ia(i+1)-ia(i)
+               ia(nn) = i
+               nn = nn-1
+            enddo
+         enddo 
+      endif
+      if ( LSAME(cpy_from,'CCS') ) then
+*---     expand ja indices ...
+         nn = nz
+         do j = ncol,1,-1
+            do k = 1,ja(j+1)-ja(j)
+               ja(nn) = j
+               nn = nn-1
+            enddo
+         enddo 
+      endif
+*
+*--   if requested, insert diagonal elements even if they are zero...
+*
+      if ( cpy_diag.eq.'D' ) then
+         nn = MIN( nrow,ncol )
+         do i = 1,nn
+            iwsp(i) = 0
+         enddo
+         do k = 1,nz
+            if ( ia(k).eq.ja(k) ) iwsp(ia(k)) = 1
+         enddo
+         do i = 1,nn
+            if ( iwsp(i).eq.0 ) then
+               nz = nz + 1
+               ia(nz) = i
+               ja(nz) = i
+               a(nz) = 0.0d0
+            endif
+         enddo
+      endif
+
+*---  COO convertion ...
+      if ( LSAME(cpy_to,'COO') ) return
+
+*---  CRS convertion ...
+      if ( LSAME(cpy_to,'CRS') ) call zcmpac( nrow,nz,ia,ja,a, iwsp )
+
+*---  CCS convertion ...
+      if ( LSAME(cpy_to,'CCS') ) call zcmpac( ncol,nz,ja,ia,a, iwsp )
+
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+*
+      subroutine zcmpac( n, nx, ix, ixx, xx, iwsp )
+*--   ZCMPAC compacts the array ix and sorts ixx and xx
+*--   (This is a gateway routine for ZGCNVR) ...
+*----------------------------------------------------------------------|
+
+      implicit none
+      integer          n, nx, ix(nx), ixx(nx), iwsp(n)
+      complex*16       xx(nx)
+      integer          k
+*
+*---  sort ix and carry ixx and xx along ...
+*
+      call izsrt2( nx, ix, ixx, xx )
+*
+*---  adjust pointers ...
+*
+      do k = 1,n
+         iwsp(k) = 0
+      enddo
+      do k = 1,nx
+         iwsp(ix(k)) = iwsp(ix(k)) + 1
+      enddo
+      ix(n+1) = nx + 1
+      do k = n,1,-1
+         ix(k) = ix(k+1)-iwsp(k)
+      enddo
+* 
+*---  sort ixx in increasing order and carry xx along ...
+*
+      do k = 1,n
+         call izsrt1( iwsp(k), ixx(ix(k)), xx(ix(k)) )
+      enddo
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+*
+      subroutine izsrt1( nx, ix, xx )
+
+*---  IZSRT1: indirect sort -- sort ix and carry xx along
+*---  adapted from a SLAP (Sparse Linear Algebra Package) code.
+*----------------------------------------------------------------------|
+
+      implicit none
+      integer          nx, ix(nx)
+      complex*16       xx(nx)
+
+      integer          M,I,J,K,IL(21),IU(21), IT,IIT,IJ,L
+      complex*16       TX, TTX
+      double precision R
+
+      if ( nx.le.1 ) return
+
+*---  And now...Just a little black magic...
+      M = 1
+      I = 1
+      J = NX
+      R = .375
+ 210  IF( R.LE.0.5898437 ) THEN
+         R = R + 3.90625E-2
+      ELSE
+         R = R-.21875
+      ENDIF
+ 225  K = I
+*
+*---  Select a central element of the array and save it in location 
+*---  IT, TX.
+*
+      IJ = I + IDINT( DBLE(J-I)*R )
+      IT = IX(IJ)
+      TX = XX(IJ)
+*
+*---  If first element of array is greater than IT, interchange with IT.
+*
+      IF( IX(I).GT.IT ) THEN
+         IX(IJ) = IX(I)
+         IX(I)  = IT
+         IT     = IX(IJ)
+         XX(IJ)  = XX(I)
+         XX(I)   = TX
+         TX     = XX(IJ)
+      ENDIF
+      L=J
+*                           
+*---  If last element of array is less than IT, swap with IT.
+*
+      IF( IX(J).LT.IT ) THEN
+         IX(IJ) = IX(J)
+         IX(J)  = IT
+         IT     = IX(IJ)
+         XX(IJ)  = XX(J)
+         XX(J)   = TX
+         TX     = XX(IJ)
+*
+*---  If first element of array is greater than IT, swap with IT.
+*
+         IF ( IX(I).GT.IT ) THEN
+            IX(IJ) = IX(I)
+            IX(I)  = IT
+            IT     = IX(IJ)
+            XX(IJ)  = XX(I)
+            XX(I)   = TX
+            TX     = XX(IJ)
+         ENDIF
+      ENDIF
+*
+*---  Find an element in the second half of the array which is 
+*---  smaller than IT.
+*
+ 240  L=L-1
+      IF( IX(L).GT.IT ) GO TO 240
+*
+*---  Find an element in the first half of the array which is 
+*---  greater than IT.
+*
+ 245  K=K+1
+      IF( IX(K).LT.IT ) GO TO 245
+*
+*---  Interchange these elements.
+*
+      IF( K.LE.L ) THEN
+         IIT   = IX(L)
+         IX(L) = IX(K)
+         IX(K) = IIT
+         TTX   = XX(L)
+         XX(L)  = XX(K)
+         XX(K)  = TTX
+         GOTO 240
+      ENDIF
+*
+*---  Save upper and lower subscripts of the array yet to be sorted.
+*
+      IF( L-I.GT.J-K ) THEN
+         IL(M) = I
+         IU(M) = L
+         I = K
+         M = M+1
+      ELSE
+         IL(M) = K
+         IU(M) = J
+         J = L
+         M = M+1
+      ENDIF
+      GO TO 260
+*
+*---  Begin again on another portion of the unsorted array.
+*
+ 255  M = M-1
+      IF( M.EQ.0 ) GO TO 300
+      I = IL(M)
+      J = IU(M)
+ 260  IF( J-I.GE.1 ) GO TO 225
+      IF( I.EQ.J ) GO TO 255
+      IF( I.EQ.1 ) GO TO 210
+      I = I-1
+ 265  I = I+1
+      IF( I.EQ.J ) GO TO 255
+      IT = IX(I+1)
+      TX =  XX(I+1)
+      IF( IX(I).LE.IT ) GO TO 265
+      K=I
+ 270  IX(K+1) = IX(K)
+      XX(K+1)  =  XX(K)
+      K = K-1
+      IF( IT.LT.IX(K) ) GO TO 270
+      IX(K+1) = IT
+      XX(K+1)  = TX
+      GO TO 265
+
+ 300  CONTINUE
+      RETURN
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine izsrt2( nx, ix, ixx, xx )
+
+*---  IZSRT2: indirect sort: sort ix and carry ixx and xx along
+*---  adapted from a SLAP (Sparse Linear Algebra Package) code.
+*----------------------------------------------------------------------|
+
+      implicit none
+      integer          nx, ix(nx), ixx(nx)
+      complex*16       xx(nx)
+
+      integer          M,I,J,K,IL(21),IU(21), IT,IIT,IJ,JT,JJT,L
+      complex*16       TX, TTX
+      double precision R
+
+      if ( nx.le.1 ) return
+
+*---  And now...Just a little black magic...
+      M = 1
+      I = 1
+      J = NX
+      R = .375
+ 210  IF( R.LE.0.5898437 ) THEN
+         R = R + 3.90625E-2
+      ELSE
+         R = R-.21875
+      ENDIF
+ 225  K = I
+*
+*---  Select a central element of the array and save it in location 
+*---  IT, JT, TX.
+*
+      IJ = I + IDINT( DBLE(J-I)*R )
+      IT = IX(IJ)
+      JT = IXX(IJ)
+      TX = XX(IJ)
+*
+*---  If first element of array is greater than IT, interchange with IT.
+*
+      IF( IX(I).GT.IT ) THEN
+         IX(IJ) = IX(I)
+         IX(I)  = IT
+         IT     = IX(IJ)
+         IXX(IJ)= IXX(I)
+         IXX(I) = JT
+         JT     = IXX(IJ)
+         XX(IJ) = XX(I)
+         XX(I)  = TX
+         TX     = XX(IJ)
+      ENDIF
+      L=J
+*                           
+*---  If last element of array is less than IT, swap with IT.
+*
+      IF( IX(J).LT.IT ) THEN
+         IX(IJ) = IX(J)
+         IX(J)  = IT
+         IT     = IX(IJ)
+         IXX(IJ)= IXX(J)
+         IXX(J) = JT
+         JT     = IXX(IJ)
+         XX(IJ) = XX(J)
+         XX(J)  = TX
+         TX     = XX(IJ)
+*
+*---  If first element of array is greater than IT, swap with IT.
+*
+         IF ( IX(I).GT.IT ) THEN
+            IX(IJ) = IX(I)
+            IX(I)  = IT
+            IT     = IX(IJ)
+            IXX(IJ)= IXX(I)
+            IXX(I) = JT
+            JT     = IXX(IJ)
+            XX(IJ) = XX(I)
+            XX(I)  = TX
+            TX     = XX(IJ)
+         ENDIF
+      ENDIF
+*
+*---  Find an element in the second half of the array which is 
+*---  smaller than IT.
+*
+ 240  L=L-1
+      IF( IX(L).GT.IT ) GO TO 240
+*
+*---  Find an element in the first half of the array which is 
+*---  greater than IT.
+*
+ 245  K=K+1
+      IF( IX(K).LT.IT ) GO TO 245
+*
+*---  Interchange these elements.
+*
+      IF( K.LE.L ) THEN
+         IIT   = IX(L)
+         IX(L) = IX(K)
+         IX(K) = IIT
+         JJT   = IXX(L)
+         IXX(L)= IXX(K)
+         IXX(K)= JJT
+         TTX   = XX(L)
+         XX(L) = XX(K)
+         XX(K) = TTX
+         GOTO 240
+      ENDIF
+*
+*---  Save upper and lower subscripts of the array yet to be sorted.
+*
+      IF( L-I.GT.J-K ) THEN
+         IL(M) = I
+         IU(M) = L
+         I = K
+         M = M+1
+      ELSE
+         IL(M) = K
+         IU(M) = J
+         J = L
+         M = M+1
+      ENDIF
+      GO TO 260
+*
+*---  Begin again on another portion of the unsorted array.
+*
+ 255  M = M-1
+      IF( M.EQ.0 ) GO TO 300
+      I = IL(M)
+      J = IU(M)
+ 260  IF( J-I.GE.1 ) GO TO 225
+      IF( I.EQ.J ) GO TO 255
+      IF( I.EQ.1 ) GO TO 210
+      I = I-1
+ 265  I = I+1
+      IF( I.EQ.J ) GO TO 255
+      IT = IX(I+1)
+      JT = IXX(I+1)
+      TX =  XX(I+1)
+      IF( IX(I).LE.IT ) GO TO 265
+      K=I
+ 270  IX(K+1) = IX(K)
+      IXX(K+1) = IXX(K)
+      XX(K+1)  =  XX(K)
+      K = K-1
+      IF( IT.LT.IX(K) ) GO TO 270
+      IX(K+1) = IT
+      IXX(K+1) = JT
+      XX(K+1)  = TX
+      GO TO 265
+
+ 300  CONTINUE
+      RETURN
+      END
+*----------------------------------------------------------------------|
+*----------------------------------------------------------------------|
+      subroutine LOADHB( filename, spformat, n, nz, ia, ja, a, iwsp )
+
+      implicit none
+      character        filename*80, spformat*3
+      integer          n, nz, ia(*), ja(*), iwsp(*)
+      double precision a(*)
+
+*---  Purpose ---------------------------------------------------------|
+*
+*---  LOADHB loads a matrix stored under the Harwell-Boeing format
+*     and renders it into the sparse format specified by spformat.
+*
+*---  Arguments -------------------------------------------------------|
+*
+*     filename (input)  
+*           name of the file containing the matrix.
+*           must end with a '$', i.e., filename is in the form: '...$'
+*
+*     spformat (input)
+*           sparse format in which the matrix is forced to be on output
+*           accepted values are:
+*              'COO' : COOrdinates
+*              'CRS' : Compressed Row Storage
+*              'CCS' : Compressed Column Storage (default H-B format)
+*
+*     n (input/output) 
+*           On input,  the maximum allowable order
+*           On output, the actual order of the matrix loaded
+*
+*     nz (input/output)
+*           On input,  the maximum allowable number of non zero entries
+*           On output, the actual number of non zero entries
+*
+*     ia,ja,a (output)
+*           sparse matrix data stored in the format given in spformat 
+*           sufficient room is needed to achieve this: each component
+*           must be of length >= nz. If the matrix is symmetric, both
+*           lower and upper parts are included explicitly
+*           
+*     iwsp (workspace) of length >= n
+*
+*----------------------------------------------------------------------|
+*
+      character        title*72, key*8, type*3, ptrfmt*16,
+     .                 indfmt*16, valfmt*20, rhsfmt*20, rhstyp*1 
+      integer          totcrd, ptrcrd, indcrd, valcrd, rhscrd, nrow,
+     .                 nrhs, nrhsix, i, j, k, io, nn, nnz
+      intrinsic        INDEX
+*---
+      i = INDEX( filename,'$' ) - 1
+      if ( i.le.0 ) stop 'in LOADHB. Bad filename'
+      open( UNIT=7, STATUS='old', IOstat=io, FILE=filename(1:i) )
+      if ( io.ne.0 ) stop 'Could not access Harwell-Boeing matrix'
+      read( UNIT=7,FMT=10 ) title, key,
+     .     totcrd, ptrcrd, indcrd, valcrd, rhscrd,
+     .     type, nrow, nn, nnz, nrhs,
+     .     ptrfmt, indfmt, valfmt, rhsfmt
+      print*, title,'type :',type,' size :',nrow,nn
+      print*,'order :',nn,' number of nonzero :',nnz
+
+      if ( nn.gt.n ) stop 'in LOADHB. Please increase n'
+      if ( nnz.gt.nz ) stop 'in LOADHB. Please increase nz'
+
+*---  leave if there is no values ... 
+      if ( valcrd.le.0 ) stop 'Empty Harwell-Boeing matrix'
+      if ( rhscrd.gt.0 ) then
+         read( UNIT=7,FMT=11 ) rhstyp, nrhs, nrhsix
+         print*,'There is a second hand'
+      endif
+
+*---  read data... 
+      read( UNIT=7,FMT=ptrfmt ) (ja(i), i = 1,nn+1)
+      read( UNIT=7,FMT=indfmt ) (ia(i), i = 1,nnz)
+      read( UNIT=7,FMT=valfmt ) (a(i),  i = 1,nnz)
+      close( UNIT=7 )
+
+*---  for the sake of experiments, store both parts if symmetric matrix
+      if ( type.eq.'RSA' ) then
+*---     expand ja indices ...
+         k = nnz
+         do j = nn,1,-1
+            do i = 1,ja(j+1)-ja(j)
+               ja(k) = j
+               k = k-1
+            enddo
+         enddo 
+*---     insert the other half ...
+         k = nnz
+         do i = 1,k
+            if ( ia(i).ne.ja(i) ) then
+               nnz = nnz + 1
+               if ( nnz.gt.nz ) stop 'in LOADHB. Please increase nz'
+               ia(nnz) = ja(i)
+               ja(nnz) = ia(i)
+               a(nnz) = a(i)
+            endif
+         enddo
+         type = 'COO'
+      else
+         type = 'CCS'
+      endif
+      call dgcnvr( type,spformat,'n', nn,nn, nnz, ia, ja, a, iwsp )
+      n = nn
+      nz = nnz
+
+      print*,'Harwell-Boeing matrix loaded'
+10    format(A72, A8/ 5i14 / A3, 11x, 4i14 / 2a16, 2a20)
+11    format(A1, 13x, 2i14)
+      end
+*----------------------------------------------------------------------|

--- a/src/include/math/expokit.h
+++ b/src/include/math/expokit.h
@@ -1,0 +1,11 @@
+#ifdef __cplusplus
+extern"C" {
+#endif
+
+// irreducible rational Pade approximation in Expokit;
+void zgpadm_(int *ideg, int *m, double *t, std::complex<double> *H, int *ldh, std::complex<double> *wsp, int *lwsp, int *ipiv, int *iexph, int *ns, int *iflag);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/src/source/math/MatExp.cpp
+++ b/src/source/math/MatExp.cpp
@@ -1,4 +1,6 @@
 #include "include/math/MatExp.h" 
+#include "include/math/expokit.h" 
+#include <complex>
 
 MatExp::MatExp(const cx_mat& m, cx_double prefactor, MatExpMethod method)
 {
@@ -25,7 +27,50 @@ void MatExp::run()
 cx_mat MatExp::pade_exp_mat()
 {
     cx_mat res;
-    res = zeros<cx_mat>(10, 10);
+    
+    // computes exp(t*H), irreducible rational Pade approximation;
+    int       ideg(6);// 
+    int       m(0);  // order of H;
+    double    t(1.0); // time-scale;
+    std::complex<double> *H(NULL);// matrix;
+    int       ldh(0);
+    std::complex<double> *wsp(NULL);
+    int       lwsp(0);
+    int       *ipiv(NULL);
+    int       iexph(0);
+    int       ns(0);
+    int       iflag(0);
+    
+    res = _prefactor * _matrix;
+    m = res.n_cols;
+    H = res.memptr();
+    if (H == NULL)
+      return zeros<cx_mat>(m, m);
+    ldh = m;
+    lwsp = 4 * m * m + ideg + 1;
+    
+    wsp = new (std::nothrow) std::complex<double> [lwsp];
+    ipiv = new (std::nothrow) int [m];
+    if ((ipiv == NULL) || (wsp == NULL))
+    {
+      delete []wsp;
+      delete []ipiv;
+      return zeros<cx_mat>(m, m);
+    }
+    
+    zgpadm_(&ideg, &m, &t, H, &ldh, wsp, &lwsp, ipiv, &iexph, &ns, &iflag);
+    
+    if (iflag < 0)
+    {
+      std::cout << "problem in ZGPADM, iflag = " << iflag << std::endl;
+      delete []wsp;
+      delete []ipiv;
+      return zeros<cx_mat>(m, m);
+    }
+    res = cx_mat( &wsp[iexph-1], m, m);// zero-based numbering;
+    
+    delete []wsp;
+    delete []ipiv;
     return res;
 }
 


### PR DESCRIPTION
add irreducible rational Pade approximation in run() of MatExp.
set MPI_INTEL=true in .bashrc to use intel compilers as the back end, otherwise use GNU compilers.
