### PR TITLE
modify Makefile for portable reason

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ INCLUDES := .  $(ARMA_INC_PATH)
 RM := rm -f
 PS = cpp
 
-CC = mpic++
+CC = mpic++ -g
 CPPFLAGS = $(addprefix -I,$(INCLUDES))
 
 ifeq ($(USE_MKL), true)
@@ -34,7 +34,7 @@ endif
 ifeq ($(HAS_MATLAB), true)
 	LIBS += mx mat eng
 	CPPFLAGS += -DHAS_MATLAB
-	LIBPATH := $(MATLAB_LIB_PATH)
+	LIBPATH := $(MATLAB_LIB_PATH) -Wl,-rpath=$(MATLAB_LIB_PATH)
 	INCLUDES += $(MATLAB_INC_PATH)
 endif
 
@@ -59,6 +59,7 @@ NCC         := nvcc
 NCFLAGS     := -arch=sm_30 -O3 -DCUBLAS_GFORTRAN -ccbin g++ -Xcompiler "$(CPPFLAGS)"
 NCLINKER    := -L/usr/local/cuda/lib64 -lcudart -lcublas -lcusparse -lboost_program_options -L/usr/local/lib #-lboost_system
 CXXLINKS    += $(NCLINKER)
+FLINKS      += $(NCLINKER)
 
 .PHONY : all clean
 
@@ -74,20 +75,24 @@ doc :
 	/Applications/Doxygen.app/Contents/Resources/doxygen ../doc/DocGen 
 
 $(addprefix $(OBJPATH)/, $(DEPS)) : $(OBJPATH)/%.d : %.cpp | $(OBJPATH)
-	@g++ -MM $< $(addprefix -I, $(INCLUDES))> $@
+	@g++ -MM -std=gnu++11 $< $(addprefix -I, $(INCLUDES))> $@
 	@sed -i="" '1s/^/..\/obj\//g' $@
 	@rm $@=
 
 -include $(addprefix $(OBJPATH)/, $(DEPS))
 
-EXPV_LIB      :=  libexpv.so
+EXPV_LIB      :=  expv
+EXPV_DIR      :=  $(ROOT_DIR)/$(OBJPATH)
+EXPV_LINKS    :=  -L$(ROOT_DIR)/$(OBJPATH) -Wl,-rpath,$(EXPV_DIR) -l$(EXPV_LIB)
+FLINKS        +=  $(EXPV_LINKS)
+CXXLINKS      +=  $(EXPV_LINKS)
 
 ifeq ($(MPI_INTEL), true)
 $(DESTINATION) : $(addprefix $(OBJPATH)/, $(OBJS)) $(OBJPATH)/$(EXPV_LIB) | $(BINPATH)
-	$(FC) -o $@ $(OBJPATH)/$(notdir $@).o $(filter-out $(APP_OBJ), $(addprefix $(OBJPATH)/, $(OBJS))) -L$(ROOT_DIR)/$(OBJPATH) -l:$(EXPV_LIB) -L$(LIBPATH) $(addprefix -l,$(LIBS)) $(FLINKS)
+	$(FC) -o $@ $(OBJPATH)/$(notdir $@).o $(filter-out $(APP_OBJ), $(addprefix $(OBJPATH)/, $(OBJS))) -L$(LIBPATH) $(addprefix -l,$(LIBS)) $(FLINKS)
 else
 $(DESTINATION) : $(addprefix $(OBJPATH)/, $(OBJS)) $(OBJPATH)/$(EXPV_LIB) | $(BINPATH)
-	$(CC) -o $@ $(OBJPATH)/$(notdir $@).o $(filter-out $(APP_OBJ), $(addprefix $(OBJPATH)/, $(OBJS))) -L$(ROOT_DIR)/$(OBJPATH) -l:$(EXPV_LIB) -L$(LIBPATH) $(addprefix -l,$(LIBS)) $(CXXLINKS)
+	$(CC) -o $@ $(OBJPATH)/$(notdir $@).o $(filter-out $(APP_OBJ), $(addprefix $(OBJPATH)/, $(OBJS))) -L$(LIBPATH) $(addprefix -l,$(LIBS)) $(CXXLINKS)
 endif
 
 $(addprefix $(OBJPATH)/, %.o) : %.cpp | $(OBJPATH)

--- a/src/expv/Makefile
+++ b/src/expv/Makefile
@@ -29,7 +29,7 @@ ZKMV_MKL_F_SRC:=  hamvec_zgexpv_w_mkl_profile.f main_mkl.f
 ZKMV_MKL_C_SRC:=  hamvec_func3.cpp
 ZKMV_GPU_F_SRC:=  zgexpv_cache.f main_cache.f
 ZKMV_GPU_C_SRC:=  hamvec_cuda3.cu get_grid.cu
-CUDAAPI_DIR   :=  /usr/local/cuda-6.0/src
+CUDAAPI_DIR   :=  /usr/local/cuda/src
 CUDAAPI_SRC   :=  fortran.c cusparse_fortran.c
 
 vpath %.f   source source/expokit
@@ -77,4 +77,7 @@ $(ZKMV_GPU_C_OBJ):$(OBJPATH)/%.o:%.cu | $(OBJPATH)
 
 $(CUDAAPI_OBJ):$(OBJPATH)/%.o:%.c | $(OBJPATH)
 	$(NCC) -c $< -o $@ $(NCFLAGS)
+
+$(OBJPATH) :
+	@mkdir -p $(OBJPATH)
 


### PR DESCRIPTION
3 modifications:

firstly, in .bashrc, remove matlab environment from LD_LIBRARY_PATH;  

secondly, in src/Makefile, append MATLAB_LIB_PATH to LIBPATH with -rpath,
LIBPATH := $(MATLAB_LIB_PATH) -Wl,-rpath=$(MATLAB_LIB_PATH) 

lastly, add c++11 option to g++ dependence
@g++ -MM -std=gnu++11 $< $(addprefix -I, $(INCLUDES))> $@
